### PR TITLE
remove encrypted password from response

### DIFF
--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -31,6 +31,8 @@ function me(req, res) {
   if (!req.user) {
     return helpers.unauthorized(res);
   }
+  delete req.user.identities?.local?.encryptedPassword;
+
   res.json(req.user);
 }
 
@@ -51,7 +53,10 @@ function updateMe(req, res) {
   req.db
     .collection('__users__')
     .findOneAndUpdate({ _id: req.user._id }, update, { returnOriginal: false })
-    .then(result => res.json(result.value))
+    .then(result => {
+      delete result.value.identities?.local?.encryptedPassword;
+      res.json(result.value);
+    })
     .catch(error => helpers.error(res, error));
 }
 


### PR DESCRIPTION
encryptedPassword was sent back to user related requests in `identities.local.encryptedPassword`

> Note: For now, user updates are done with PUT and not PATCH in caas-styleguide. => I'll make another branch to add PATCH to auth service. Because the complete user is sent as payload, stripped out of encryptedPassword so the user is updated into DB without any password.