### PR TITLE
Use set operator for patch with empty string value

### DIFF
--- a/services/docs/lib/modules/queryBuilder.js
+++ b/services/docs/lib/modules/queryBuilder.js
@@ -141,8 +141,7 @@ module.exports.patch = async options => {
     : null;
 
   for (const [key, value] of Object.entries(options.data)) {
-    const operator =
-      value === '' || value === null || value === undefined ? '$unset' : '$set';
+    const operator = value === null || value === undefined ? '$unset' : '$set';
     ops[operator][join('states', state.name, 'data', key)] = value;
   }
 


### PR DESCRIPTION
As discussed, including the empty string value in $unset case create issues, we should use the $set operator.