### PR TITLE
Fix embed relationships subdocs

### DIFF
--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -185,7 +185,14 @@ module.exports.patchDoc = async (req, res) => {
 // get a doc
 module.exports.getDoc = function(req, res) {
   documentService
-    .getDocument(req.resource, req.filter, req.query, req.user, req.state)
+    .getDocument(
+      req.resource,
+      req.filter,
+      req.query,
+      req.user,
+      req.state,
+      req.options.resources
+    )
     .then(result => helpers.json(res, result))
     .catch(err => helpers.notFound(res, err));
 };
@@ -238,12 +245,7 @@ module.exports.postDocUser = function(req, res) {
 
 module.exports.delDocUser = function(req, res) {
   documentService
-    .removeUserFromDocument(
-      req.resource,
-      req.filter,
-      req.params.user,
-      req.db
-    )
+    .removeUserFromDocument(req.resource, req.filter, req.params.user, req.db)
     .then(users =>
       userService.fetchUsers(users, req.options, req.service.server)
     )

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -33,7 +33,8 @@ module.exports.getDocuments = function(req, res) {
       req.query,
       req.state,
       req.query.sort,
-      pagination
+      pagination,
+      req.options.resources
     )
     .then(data => {
       let links = [];

--- a/services/docs/lib/modules/embedDocs.js
+++ b/services/docs/lib/modules/embedDocs.js
@@ -2,27 +2,19 @@ const async = require('async');
 const ObjectId = require('mongodb').ObjectId;
 const findRefs = require('campsi-find-references');
 
-function fetchSubdoc (resource, reference, user, hash) {
+function fetchSubdoc(resource, reference, user) {
   const _id = reference.get();
   return new Promise((resolve, reject) => {
-    if (typeof hash[_id] !== 'undefined') {
-      reference.set(hash[_id]);
-      return resolve();
-    }
-
     resource.collection.findOne(
-      {_id: new ObjectId(_id)},
-      {_id: 1, states: 1},
+      { _id: new ObjectId(_id) },
+      { _id: 1, states: 1 },
       (err, subDoc) => {
         if (err) return reject(err);
-        hash[_id] = subDoc.states[resource.defaultState].data;
-        reference.set(hash[_id]);
-        return resolve();
+        return resolve(subDoc.states[resource.defaultState].data);
       }
     );
   });
 }
-
 /**
  *
  * @param {Resource} resource
@@ -31,36 +23,51 @@ function fetchSubdoc (resource, reference, user, hash) {
  * @param {User} user
  * @param {Object} doc
  * @param {Object} [hash]
+ * @param {Resource|]} resources
  * @returns {Promise}
  */
-function embedDocs (resource, embed, user, doc, hash) {
-  hash = hash || {};
+function embedDocs(resource, embed, user, doc, resources) {
   return new Promise((resolve, reject) => {
     let error;
-    async.eachOf(resource.rels || {}, (relationship, name, cb) => {
-      const embedRel = (relationship.embed || (embed && embed.includes(name)));
-      if (!embedRel) {
-        return async.setImmediate(cb);
-      }
+    async.eachOf(
+      resource.rels || {},
+      (relationship, name, cb) => {
+        const embedRel = relationship.embed || (embed && embed.includes(name));
+        if (!embedRel) {
+          return async.setImmediate(cb);
+        }
 
-      const references = findRefs(doc, relationship.path.split('.'));
-      async.each(references, (reference, refCb) => {
-        fetchSubdoc(
-          resource.schema.resources[relationship.resource],
-          reference,
-          user,
-          hash
-        ).then(refCb);
-      }, cb);
-    }, () => (error) ? reject(error) : resolve());
+        const references = findRefs(doc, relationship.path.split('.'));
+        async.each(
+          references,
+          (reference, refCb) => {
+            fetchSubdoc(resources[relationship.resource], reference, user).then(
+              subdoc => {
+                doc[embed] = {};
+                relationship.fields.forEach(field => {
+                  doc[embed][field] = subdoc[field];
+                });
+                refCb();
+              }
+            );
+          },
+          cb
+        );
+      },
+      () => (error ? reject(error) : resolve(doc))
+    );
   });
 }
 module.exports.one = embedDocs;
-module.exports.many = function (resource, embed, user, docs) {
+module.exports.many = function(resource, embed, user, docs) {
   let hash = {};
-  return new Promise((resolve) => {
-    async.forEach(docs, (doc, cb) => {
-      embedDocs(resource, embed, user, doc.data, hash).then(cb);
-    }, resolve);
+  return new Promise(resolve => {
+    async.forEach(
+      docs,
+      (doc, cb) => {
+        embedDocs(resource, embed, user, doc.data, hash).then(cb);
+      },
+      resolve
+    );
   });
 };

--- a/services/docs/lib/modules/embedDocs.js
+++ b/services/docs/lib/modules/embedDocs.js
@@ -59,13 +59,15 @@ function embedDocs(resource, embed, user, doc, resources) {
   });
 }
 module.exports.one = embedDocs;
-module.exports.many = function(resource, embed, user, docs) {
-  let hash = {};
+module.exports.many = function(resource, embed, user, docs, resources) {
   return new Promise(resolve => {
     async.forEach(
       docs,
       (doc, cb) => {
-        embedDocs(resource, embed, user, doc.data, hash).then(cb);
+        embedDocs(resource, embed, user, doc.data, resources).then(doc => {
+          cb();
+          return doc;
+        });
       },
       resolve
     );

--- a/services/docs/lib/modules/embedDocs.js
+++ b/services/docs/lib/modules/embedDocs.js
@@ -2,7 +2,7 @@ const async = require('async');
 const ObjectId = require('mongodb').ObjectId;
 const findRefs = require('campsi-find-references');
 
-function fetchSubdoc(resource, reference, user) {
+function fetchSubdoc(resource, reference) {
   const _id = reference.get();
   return new Promise((resolve, reject) => {
     resource.collection.findOne(
@@ -41,7 +41,7 @@ function embedDocs(resource, embed, user, doc, resources) {
         async.each(
           references,
           (reference, refCb) => {
-            fetchSubdoc(resources[relationship.resource], reference, user).then(
+            fetchSubdoc(resources[relationship.resource], reference).then(
               subdoc => {
                 doc[embed] = {};
                 relationship.fields.forEach(field => {

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -391,14 +391,7 @@ module.exports.getDocument = function(
             user
           });
           embedDocs
-            .one(
-              resource,
-              resource.schema,
-              query.embed,
-              user,
-              returnValue.data,
-              resources
-            )
+            .one(resource, query.embed, user, returnValue.data, resources)
             .then(doc => resolve(returnValue));
         })
         .catch(err => {

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -19,7 +19,8 @@ module.exports.getDocuments = function(
   query,
   state,
   sort,
-  pagination
+  pagination,
+  resources
 ) {
   const queryBuilderOptions = {
     resource: resource,
@@ -179,7 +180,13 @@ module.exports.getDocuments = function(
           }
           return returnData;
         });
-        return embedDocs.many(resource, query.embed, user, result.docs);
+        return embedDocs.many(
+          resource,
+          query.embed,
+          user,
+          result.docs,
+          resources
+        );
       })
       .then(() => {
         return resolve(result);
@@ -384,8 +391,15 @@ module.exports.getDocument = function(
             user
           });
           embedDocs
-            .one(resource, resource.schema, query.embed, user, returnValue.data)
-            .then(() => resolve(returnValue));
+            .one(
+              resource,
+              resource.schema,
+              query.embed,
+              user,
+              returnValue.data,
+              resources
+            )
+            .then(doc => resolve(doc));
         })
         .catch(err => {
           reject(err);

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -286,7 +286,14 @@ module.exports.patchDocument = async (resource, filter, data, state, user) => {
   };
 };
 
-module.exports.getDocument = function(resource, filter, query, user, state) {
+module.exports.getDocument = function(
+  resource,
+  filter,
+  query,
+  user,
+  state,
+  resources
+) {
   const requestedStates = getRequestedStatesFromQuery(resource, query);
   const fields = { _id: 1, states: 1, users: 1, groups: 1 };
   const match = { ...filter };
@@ -311,8 +318,10 @@ module.exports.getDocument = function(resource, filter, query, user, state) {
           user
         });
         embedDocs
-          .one(resource, resource.schema, query.embed, user, returnValue.data)
-          .then(() => resolve(returnValue));
+          .one(resource, query.embed, user, returnValue.data, resources)
+          .then(doc => {
+            resolve(doc);
+          });
       });
     });
   } else {
@@ -357,7 +366,6 @@ module.exports.getDocument = function(resource, filter, query, user, state) {
         }
       }
     ];
-
     return new Promise((resolve, reject) => {
       resource.collection
         .aggregate(pipeline)

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -327,7 +327,7 @@ module.exports.getDocument = function(
         embedDocs
           .one(resource, query.embed, user, returnValue.data, resources)
           .then(doc => {
-            resolve(doc);
+            resolve(returnValue);
           });
       });
     });
@@ -399,7 +399,7 @@ module.exports.getDocument = function(
               returnValue.data,
               resources
             )
-            .then(doc => resolve(doc));
+            .then(doc => resolve(returnValue));
         })
         .catch(err => {
           reject(err);


### PR DESCRIPTION
fetching relations was planned on campsi but was not working and never finished.
I finished it and cleaned up a little.
For this to work, you have to add a `rel` property when you define resources, for instance:
```javascript
projects: {
  label: 'project',
  class: 'versionedEntry',
  schema: require('./schemas/project.schema'),
  rels: {
    organization: {
      path: 'organizationId',
      resource: 'organizations',
      fields: ['companyName', 'subscription', '_id']
    }
  }
}
```
and adding `resources` in the schema, for instance:
```json
"resources": [
    "organizations"
  ]
```