### PR TITLE
reject error instead of throwing it on document creation

### DIFF
--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -230,8 +230,8 @@ module.exports.createDocument = function(
           doc.groups = [...new Set([...doc.groups, ...groups])];
         }
 
-        await resource.collection.insertOne(doc, (err, result) => {
-          if (err) throw err;
+        resource.collection.insertOne(doc, (err, result) => {
+          if (err) return reject(err);
           resolve(
             Object.assign(
               {


### PR DESCRIPTION
error was never catched => could crash api