### PR TITLE
stripe API update from 2019-08-14 to 2020-08-27 version

### DIFF
--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -15,7 +15,8 @@ const bodyToCustomer = (body, sourcePropertyName, user) => {
       body.metadata || {},
       user ? { user: user._id.toString() } : {}
     ),
-    shipping: body.shipping
+    shipping: body.shipping,
+    expand: ['tax_ids']
   };
 };
 
@@ -65,6 +66,11 @@ module.exports = class StripeBillingService extends CampsiService {
     });
 
     this.router.get('/customers/:id', (req, res) => {
+      req.query.expand = req.query.expand
+        ? req.query.expand.includes('tax_ids')
+          ? req.query.expand
+          : `${req.query.expand}|tax_ids`
+        : 'tax_ids';
       stripe.customers.retrieve(
         req.params.id,
         optionsFromQuery(req.query),


### PR DESCRIPTION
https://stripe.com/docs/upgrades#2020-08-27
# 2020-08-27
> The tax_ids property on Customers is no longer included by default. You can expand the list but for performance reasons we recommended against doing so unless needed.

- add tax_ids as expand on create/retrieve/update for customers