### PR TITLE
stripe: check code validity and version updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "passport-github2": "^0.1.10",
         "request": "^2.88.2",
         "string-format": "^2.0.0",
-        "stripe": "^7.9.0",
+        "stripe": "^8.194.0",
         "unique-slug": "^2.0.0",
         "uuid": "^3.4.0",
         "yargs": "^16.1.0"
@@ -426,8 +426,7 @@
     "node_modules/@types/node": {
       "version": "16.4.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
-      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==",
-      "dev": true
+      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -5991,14 +5990,15 @@
       }
     },
     "node_modules/stripe": {
-      "version": "7.63.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-7.63.1.tgz",
-      "integrity": "sha512-W6R2CzMF87DeWVtxrAD8E9As62VIu2M9Ece+YKVw2P4oOBgvj5M2F2xH8R5VMmnDtmx4RJtg8PIJ4DmijpLU6g==",
+      "version": "8.194.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.194.0.tgz",
+      "integrity": "sha512-iERByJUNA7sdkfQ3fD1jcrAZqPxCtTmL2EUzvHUVLXyoacDrflkq4ux5KFxYhfCIerrOAhquVj17+sBHn96/Kg==",
       "dependencies": {
+        "@types/node": ">=8.1.0",
         "qs": "^6.6.0"
       },
       "engines": {
-        "node": "^6 || ^8.1 || >=10.*"
+        "node": "^8.1 || >=10.*"
       }
     },
     "node_modules/stripe/node_modules/qs": {
@@ -6950,8 +6950,7 @@
     "@types/node": {
       "version": "16.4.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
-      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==",
-      "dev": true
+      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -7579,7 +7578,7 @@
         "request": "^2.88.2",
         "rimraf": "^2.7.1",
         "string-format": "^2.0.0",
-        "stripe": "^7.9.0",
+        "stripe": "^8.194.0",
         "unique-slug": "^2.0.0",
         "uuid": "^3.4.0",
         "yargs": "^16.1.0"
@@ -7854,8 +7853,7 @@
         "@types/node": {
           "version": "16.4.3",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
-          "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==",
-          "dev": true
+          "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg=="
         },
         "@types/parse-json": {
           "version": "4.0.0",
@@ -12140,10 +12138,11 @@
           "dev": true
         },
         "stripe": {
-          "version": "7.63.1",
-          "resolved": "https://registry.npmjs.org/stripe/-/stripe-7.63.1.tgz",
-          "integrity": "sha512-W6R2CzMF87DeWVtxrAD8E9As62VIu2M9Ece+YKVw2P4oOBgvj5M2F2xH8R5VMmnDtmx4RJtg8PIJ4DmijpLU6g==",
+          "version": "8.194.0",
+          "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.194.0.tgz",
+          "integrity": "sha512-iERByJUNA7sdkfQ3fD1jcrAZqPxCtTmL2EUzvHUVLXyoacDrflkq4ux5KFxYhfCIerrOAhquVj17+sBHn96/Kg==",
           "requires": {
+            "@types/node": ">=8.1.0",
             "qs": "^6.6.0"
           },
           "dependencies": {
@@ -16403,10 +16402,11 @@
       "dev": true
     },
     "stripe": {
-      "version": "7.63.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-7.63.1.tgz",
-      "integrity": "sha512-W6R2CzMF87DeWVtxrAD8E9As62VIu2M9Ece+YKVw2P4oOBgvj5M2F2xH8R5VMmnDtmx4RJtg8PIJ4DmijpLU6g==",
+      "version": "8.194.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.194.0.tgz",
+      "integrity": "sha512-iERByJUNA7sdkfQ3fD1jcrAZqPxCtTmL2EUzvHUVLXyoacDrflkq4ux5KFxYhfCIerrOAhquVj17+sBHn96/Kg==",
       "requires": {
+        "@types/node": ">=8.1.0",
         "qs": "^6.6.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "passport-github2": "^0.1.10",
     "request": "^2.88.2",
     "string-format": "^2.0.0",
-    "stripe": "^7.9.0",
+    "stripe": "^8.194.0",
     "unique-slug": "^2.0.0",
     "uuid": "^3.4.0",
     "yargs": "^16.1.0"

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -124,6 +124,7 @@ module.exports = class StripeBillingService extends CampsiService {
           items: req.body.items,
           metadata: req.body.metadata,
           coupon: req.body.coupon,
+          promotion_code: req.body.promotion_code,
           expand: subscriptionExpand,
           default_tax_rates: req.body.default_tax_rates
         },
@@ -151,6 +152,7 @@ module.exports = class StripeBillingService extends CampsiService {
           items: req.body.items,
           metadata: req.body.metadata,
           coupon: req.body.coupon,
+          promotion_code: req.body.promotion_code,
           expand: subscriptionExpand,
           default_tax_rates: req.body.default_tax_rates
         },

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -229,7 +229,7 @@ module.exports = class StripeBillingService extends CampsiService {
     });
 
     if (promoCodes.data.length) {
-      return res.json(promoCodes.data[0].coupon);
+      return res.json(promoCodes.data[0]);
     }
     // no promocode => let's find if there's a valid coupon with code as its id
     try {


### PR DESCRIPTION
Checks if coupon or promotion code is valid, and return it

I've also updated stripe to its latest version, because promotion codes resource was not available on versions lower than 8.83.0
all checks have been done following this migration guide: https://github.com/stripe/stripe-node/wiki/Migration-guide-for-v8 and payment end-to-end tests have been run successfully