### PR TITLE
refactor: remove uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "string-format": "^2.0.0",
     "stripe": "^8.194.0",
     "unique-slug": "^2.0.0",
-    "uuid": "^3.4.0",
     "yargs": "^16.1.0"
   },
   "devDependencies": {
@@ -92,5 +91,9 @@
     "index.js",
     "lib/",
     "services/"
-  ]
+  ],
+  "engines": {
+    "node": ">=14.17.0",
+    "npm": ">=7"
+  }
 }

--- a/services/auth/lib/modules/queryBuilder.js
+++ b/services/auth/lib/modules/queryBuilder.js
@@ -1,4 +1,4 @@
-const uuid = require('uuid');
+const { randomUUID: uuid } = require('crypto');
 
 function filterUserByEmailOrProviderId(provider, profile) {
   let query = { $or: [] };


### PR DESCRIPTION
I kept getting warnings about updating uuid. The thing is, we don't need it anymore since we can natively generate uuid since node 14.17.0 => this PR