### PR TITLE
refactor: docs service attachResource refactored for external usage

### DIFF
--- a/services/docs/lib/param.js
+++ b/services/docs/lib/param.js
@@ -1,51 +1,56 @@
 const helpers = require('../../../lib/modules/responseHelpers');
 const createObjectId = require('../../../lib/modules/createObjectId');
 const { can } = require('./modules/permissions');
-const { ObjectId } = require('mongodb');
 const {
   getValidGroupsFromString
 } = require('../../../lib/modules/groupsHelpers');
+const createError = require('http-errors');
 
 module.exports.attachResource = function(options) {
   return (req, res, next) => {
-    if (req.params.resource) {
-      req.resource = options.resources[req.params.resource];
+    this.attach(req, res, next, options);
+  };
+};
 
-      // Unknown resource ?
-      if (!req.resource) {
+module.exports.attach = (req, res, next, options) => {
+  if (req.params.resource) {
+    req.resource = options.resources[req.params.resource];
+
+    // Unknown resource ?
+    if (!req.resource) {
+      return helpers.notFound(res);
+    }
+
+    // Is state defined for this resource ?
+    const state = req.params.state || req.query.state;
+    if (state) {
+      if (typeof req.resource.states[state] === 'undefined') {
         return helpers.notFound(res);
       }
-
-      // Is state defined for this resource ?
-      const state = req.params.state || req.query.state;
-      if (state) {
-        if (typeof req.resource.states[state] === 'undefined') {
-          return helpers.notFound(res);
-        }
-        req.state = state;
-      } else {
-        req.state = req.resource.defaultState;
-      }
-
-      // Is ID well-formed ?
-      if (req.params.id) {
-        req.filter = { _id: createObjectId(req.params.id) };
-        if (!req.filter._id) {
-          return helpers.error(res, new Error("Can't recognize id"));
-        }
-      }
-
-      req.groups = req.query?.groups
-        ? getValidGroupsFromString(req.query.groups)
-        : [];
-
-      // USER can access RESOURCE/FILTER with METHOD/STATE ?
-      can(req.user, req.resource, req.method, req.state)
-        .then(filter => {
-          req.filter = Object.assign({}, req.filter, filter);
-          next();
-        })
-        .catch(err => helpers.unauthorized(res, err));
+      req.state = state;
+    } else {
+      req.state = req.resource.defaultState;
     }
-  };
+
+    // Is ID well-formed ?
+    if (req.params.id) {
+      req.filter = { _id: createObjectId(req.params.id) };
+      if (!req.filter._id) {
+        throw new createError.BadRequest("Can't recognize proper id");
+      }
+    }
+
+    req.groups = req.query?.groups
+      ? getValidGroupsFromString(req.query.groups)
+      : [];
+
+    // USER can access RESOURCE/FILTER with METHOD/STATE ?
+    try {
+      const filter = can(req.user, req.resource, req.method, req.state);
+      req.filter = { ...req.filter, ...filter };
+      next();
+    } catch (err) {
+      throw new createError.Unauthorized(err.message);
+    }
+  }
 };

--- a/services/versioned-docs/lib/param.js
+++ b/services/versioned-docs/lib/param.js
@@ -1,4 +1,3 @@
-const helpers = require('../../../lib/modules/responseHelpers');
 const createObjectId = require('../../../lib/modules/createObjectId');
 const { can } = require('./modules/permissions');
 const {


### PR DESCRIPTION
# Why?
I need to "fake" docs service `attachResource` in caas-api to avoid code duplication. That's all