### PR TITLE
refactor: patched event renamed for more precise usage

### DIFF
--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -120,7 +120,7 @@ module.exports.patchDoc = async (req, res) => {
   try {
     const result = await documentService.patchDocument(req.resource, req.filter, req.body, req.state, req.user);
     helpers.json(res, result);
-    req.service.emit('document/updated', getEmitPayload(req, { data: req.body }));
+    req.service.emit('document/patched', getEmitPayload(req, { data: req.body }));
   } catch (err) {
     switch (err.message) {
       case 'Validation Error': {
@@ -145,7 +145,7 @@ module.exports.getDoc = function(req, res) {
 module.exports.delDoc = function(req, res) {
   documentService
     .deleteDocument(req.resource, req.filter)
-    .then((result) => {
+    .then(result => {
       result.deletedCount === 0 ? helpers.notFound(res, result) : helpers.json(res, result);
     })
     .then(() => req.service.emit('document/deleted', getEmitPayload(req)))

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -118,9 +118,17 @@ module.exports.putDoc = function(req, res) {
 
 module.exports.patchDoc = async (req, res) => {
   try {
+    const originalDoc = await documentService.getDocument(
+      req.resource,
+      req.filter,
+      req.query,
+      req.user,
+      req.state,
+      req.options.resources
+    );
     const result = await documentService.patchDocument(req.resource, req.filter, req.body, req.state, req.user);
     helpers.json(res, result);
-    req.service.emit('document/patched', getEmitPayload(req, { data: req.body }));
+    req.service.emit('document/patched', getEmitPayload(req, { data: req.body, originalDocData: originalDoc.data }));
   } catch (err) {
     switch (err.message) {
       case 'Validation Error': {

--- a/services/versioned-docs/lib/handlers.js
+++ b/services/versioned-docs/lib/handlers.js
@@ -69,14 +69,14 @@ module.exports.postDoc = async (req, res, next) => {
   const doc = await documentService.createDocument(req.resource, req.body, req.user, req.groups);
   res.set('ETag', doc.revision);
   helpers.json(res, doc);
-  return req.service.emit('document/created', getEmitPayload(req, { doc }));
+  return req.service.emit('versionedDocument/created', getEmitPayload(req, { doc }));
 };
 
 module.exports.updateDoc = async (req, res, next) => {
   const result = await documentService.updateDocument(req.resource, req.filter, req.body, req.user, getETagFromIfMatch(req));
   res.set('ETag', result.revision);
   helpers.json(res, result);
-  return req.service.emit('document/updated', getEmitPayload(req, { data: req.body }));
+  return req.service.emit('versionedDocument/updated', getEmitPayload(req, { data: req.body }));
 };
 
 module.exports.getDoc = async (req, res, next) => {
@@ -124,7 +124,7 @@ module.exports.getDocVersion = async (req, res, next) => {
 module.exports.delDoc = async (req, res, next) => {
   const result = await documentService.deleteDocument(req.resource, req.filter, req.query);
   helpers.json(res, result);
-  return req.service.emit('document/deleted', getEmitPayload(req));
+  return req.service.emit('versionedDocument/deleted', getEmitPayload(req));
 };
 
 module.exports.getResources = function(req, res, next) {
@@ -145,7 +145,7 @@ module.exports.postDocUser = async (req, res, next) => {
 
   helpers.json(res, users);
 
-  return req.service.emit('document/users/added', getEmitPayload(req, { addedUserId: req.body.userId }));
+  return req.service.emit('versionedDocument/users/added', getEmitPayload(req, { addedUserId: req.body.userId }));
 };
 
 module.exports.delDocUser = async (req, res, next) => {
@@ -154,5 +154,5 @@ module.exports.delDocUser = async (req, res, next) => {
 
   const users = await userService.fetchUsers(usersId, req.options, req.service.server);
   helpers.json(res, users);
-  return req.service.emit('document/users/removed', getEmitPayload(req, { removedUserId: req.params.user }));
+  return req.service.emit('versionedDocument/users/removed', getEmitPayload(req, { removedUserId: req.params.user }));
 };


### PR DESCRIPTION
The main purpose of this PR is to rename event emitted by docs.patch to handle this specific case (i don't want to handle it the same way as put events). I've also added the original document data to the emitted payload since I need it to check what's been unset, if any 
I also renamed all versioned docs service events because they had the same name as docs service events.