### PR TITLE
Jameslotery/axe 791 update eslint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,26 +8,28 @@
     "ecmaVersion": 2021
   },
   "plugins": [
-    "indexof"
+    "indexof",
+    "prettier"
   ],
   "extends": [
     "eslint:recommended",
     "standard",
     "plugin:import/recommended",
-    "plugin:node/recommended",
-    "plugin:promise/recommended"
+    "plugin:node/recommended"
   ],
   "rules": {
     // Exception
-    "semi": ["error", "always"],
+    "semi": ["warn", "always"],
+
     // Format xtras
-    "max-len": ["error", 130],
-    "max-lines": ["error", 400],
-    "max-statements": ["error", 20],
+    "max-len": ["warn", 130],
     "linebreak-style": ["error", "unix"],
     "space-before-function-paren": ["off"],
+
     // Other xtras
-    "strict": ["error", "never"],
-    "indexof/no-indexof": ["error"]
+    "strict": ["warn", "never"],
+    "indexof/no-indexof": ["warn"],
+
+    "prettier/prettier": 1 // Means Warn
   }
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm test
+npm lint

--- a/lib/keywords/csdAssign.js
+++ b/lib/keywords/csdAssign.js
@@ -1,47 +1,61 @@
-let sequences = {};
+const sequences = {};
 
-let DEFAULTS = {
-  timestamp: function () { return Date.now(); },
-  datetime: function () { return (new Date()).toISOString(); },
-  date: function () { return (new Date()).toISOString().slice(0, 10); },
-  time: function () { return (new Date()).toISOString().slice(11); },
-  random: function () { return Math.random(); },
-  randomint: function (args) {
-    const limit = (args && args.max) || 2;
-    return function () { return Math.floor(Math.random() * limit); };
+const DEFAULTS = {
+  timestamp: function() {
+    return Date.now();
   },
-  seq: function (args) {
+  datetime: function() {
+    return new Date().toISOString();
+  },
+  date: function() {
+    return new Date().toISOString().slice(0, 10);
+  },
+  time: function() {
+    return new Date().toISOString().slice(11);
+  },
+  random: function() {
+    return Math.random();
+  },
+  randomint: function(args) {
+    const limit = (args && args.max) || 2;
+    return function() {
+      return Math.floor(Math.random() * limit);
+    };
+  },
+  seq: function(args) {
     const name = (args && args.name) || '';
     sequences[name] = sequences[name] || 0;
-    return function () { return sequences[name]++; };
+    return function() {
+      return sequences[name]++;
+    };
   }
 };
 
-module.exports = function defFunc (ajv) {
+module.exports = function defFunc(ajv) {
   defFunc.definition = {
-    compile: function (schema, parentSchema, it) {
-      let funcs = {};
+    compile: function(schema, parentSchema, it) {
+      const funcs = {};
 
-      for (let key in schema) {
+      for (const key in schema) {
         const d = schema[key];
         const func = getDefault(typeof d === 'string' ? d : d.func);
         funcs[key] = func.length ? func(d.args) : func;
       }
 
-      return it.opts.useAssign && !it.compositeRule
-        ? assign
-        : noop;
+      return it.opts.useAssign && !it.compositeRule ? assign : noop;
 
-      function assign (data) {
-        for (let prop in schema) {
+      function assign(data) {
+        for (const prop in schema) {
           data[prop] = funcs[prop]();
         }
         return true;
       }
 
-      function noop () { return true; }
+      function noop() {
+        return true;
+      }
     },
-    DEFAULTS: DEFAULTS,
+    DEFAULTS,
     metaSchema: {
       type: 'object',
       additionalProperties: {
@@ -59,7 +73,7 @@ module.exports = function defFunc (ajv) {
   ajv.addKeyword('csd-assign', defFunc.definition);
   return ajv;
 
-  function getDefault (d) {
+  function getDefault(d) {
     const def = DEFAULTS[d];
     if (def) return def;
     throw new Error('invalid "csdAssign" keyword property value: ' + d);

--- a/lib/keywords/csdVisibility.js
+++ b/lib/keywords/csdVisibility.js
@@ -1,20 +1,18 @@
-module.exports = function defFunc (ajv) {
+module.exports = function defFunc(ajv) {
   defFunc.definition = {
-    compile: function (schema, parentSchema, it) {
-      let strings = {};
+    compile: function(schema, parentSchema, it) {
+      const strings = {};
 
-      for (let key in schema) {
+      for (const key in schema) {
         const d = schema[key];
         const string = typeof d === 'string' ? d : undefined;
         strings[key] = string;
       }
 
-      return it.opts.useVisibility && !it.compositeRule
-        ? assign
-        : noop;
+      return it.opts.useVisibility && !it.compositeRule ? assign : noop;
 
-      function assign (data) {
-        for (let prop in schema) {
+      function assign(data) {
+        for (const prop in schema) {
           if (strings[prop]) {
             data[prop] = strings[prop];
           } else {
@@ -24,7 +22,9 @@ module.exports = function defFunc (ajv) {
         return true;
       }
 
-      function noop () { return true; }
+      function noop() {
+        return true;
+      }
     },
     metaSchema: {
       type: 'object',

--- a/lib/modules/buildLink.js
+++ b/lib/modules/buildLink.js
@@ -1,13 +1,15 @@
-module.exports = function buildLink (req, page, keptParams) {
-  let params = {
-    page: page
+module.exports = function buildLink(req, page, keptParams) {
+  const params = {
+    page
   };
-  for (let keptParam of keptParams) {
-    if (req.query && req.query.hasOwnProperty(keptParam)) {
+  for (const keptParam of keptParams) {
+    if (Object.prototype.hasOwnProperty.call(req.query, keptParam)) {
       params[keptParam] = req.query[keptParam];
     }
   }
-  let path = req.baseUrl + req.path;
-  let query = Object.keys(params).map(k => encodeURIComponent(k) + '=' + encodeURIComponent(params[k])).join('&');
+  const path = req.baseUrl + req.path;
+  const query = Object.keys(params)
+    .map(k => encodeURIComponent(k) + '=' + encodeURIComponent(params[k]))
+    .join('&');
   return '{0}://{1}{2}?{3}'.format(req.protocol, req.get('host'), path, query);
 };

--- a/lib/modules/groupsHelpers.js
+++ b/lib/modules/groupsHelpers.js
@@ -1,12 +1,15 @@
 const { ObjectId } = require('mongodb');
 
-module.exports.getValidGroupsFromString = function getValidGroupsFromString(
-  groupIds
-) {
+module.exports.getValidGroupsFromString = function getValidGroupsFromString(groupIds) {
   return groupIds
     .split(',')
-    .map((groupId) => {
-      return ObjectId.isValid(groupId.trim().split('_').pop())
+    .map(groupId => {
+      return ObjectId.isValid(
+        groupId
+          .trim()
+          .split('_')
+          .pop()
+      )
         ? groupId.trim()
         : false;
     })

--- a/lib/modules/parseJSON.js
+++ b/lib/modules/parseJSON.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const BYTE_ORDER_MARK = /^\ufeff/g;
 
-module.exports = function parseJSON (filename) {
+module.exports = function parseJSON(filename) {
   return new Promise((resolve, reject) => {
     let json = null;
     fs.readFile(filename, 'utf8', (err, content) => {

--- a/lib/modules/responseHelpers.js
+++ b/lib/modules/responseHelpers.js
@@ -18,31 +18,31 @@ function send(res, status, body) {
 
 // 4xx Errors
 module.exports.badRequest = function(res, err) {
-  let body = { message: 'bad request' };
+  const body = { message: 'bad request' };
   buildBody(body, err);
   send(res, 400, body);
 };
 
 module.exports.unauthorized = function(res, err) {
-  let body = { message: 'unauthorized' };
+  const body = { message: 'unauthorized' };
   buildBody(body, err);
   send(res, 401, body);
 };
 
 module.exports.forbidden = function(res, err) {
-  let body = { message: 'forbidden' };
+  const body = { message: 'forbidden' };
   buildBody(body, err);
   send(res, 403, body);
 };
 
 module.exports.notFound = function(res, err) {
-  let body = { message: 'not found' };
+  const body = { message: 'not found' };
   buildBody(body, err);
   send(res, 404, body);
 };
 
 module.exports.conflict = function(res, err) {
-  let body = {
+  const body = {
     message: 'conflict'
   };
   buildBody(body, err);
@@ -50,7 +50,7 @@ module.exports.conflict = function(res, err) {
 };
 
 module.exports.preconditionFailed = function(res, err) {
-  let body = {
+  const body = {
     message: 'precondition failed'
   };
   buildBody(body, err);
@@ -58,26 +58,26 @@ module.exports.preconditionFailed = function(res, err) {
 };
 
 module.exports.missingParameters = function(res, err) {
-  let body = { message: 'missing parameter(s)' };
+  const body = { message: 'missing parameter(s)' };
   buildBody(body, err);
   send(res, 422, body);
 };
 
 // 5xx Errors
 module.exports.internalServerError = function(res, err) {
-  let body = { message: 'internal server error' };
+  const body = { message: 'internal server error' };
   buildBody(body, err);
   send(res, 500, body);
 };
 
 module.exports.notImplemented = function(res, err) {
-  let body = { message: 'not implemented' };
+  const body = { message: 'not implemented' };
   buildBody(body, err);
   send(res, 501, body);
 };
 
 module.exports.serviceNotAvailable = (res, err) => {
-  let body = { message: 'service unavailable' };
+  const body = { message: 'service unavailable' };
   buildBody(body, err);
   send(res, 503, body);
 };
@@ -104,6 +104,7 @@ module.exports.validationError = function validationError(res) {
 // Json Helper
 module.exports.json = function json(res, body, headers) {
   if (headers) {
+    // eslint-disable-next-line array-callback-return
     Object.entries(headers).map(([key, value]) => {
       res.header(key, value);
     });

--- a/lib/modules/sortCursor.js
+++ b/lib/modules/sortCursor.js
@@ -4,10 +4,8 @@
  * @param {String} prefix
  * @returns {Array<Array>}
  */
-function getMongoSortArray (field, prefix) {
-  return (!field.startsWith('-'))
-    ? [prefix + field, 1]
-    : [prefix + field.substr(1), -1];
+function getMongoSortArray(field, prefix) {
+  return !field.startsWith('-') ? [prefix + field, 1] : [prefix + field.substr(1), -1];
 }
 
 /**
@@ -25,7 +23,7 @@ module.exports = (cursor, sort, prefix) => {
 
   prefix = prefix === undefined ? '' : String(prefix);
 
-  let fields = sort.split(',').map((field) => getMongoSortArray(field, prefix));
+  const fields = sort.split(',').map(field => getMongoSortArray(field, prefix));
   cursor.sort(fields);
   return cursor;
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,9 +3,9 @@ const debug = require('debug')('campsi');
 const MQTTEmitter = require('mqtt-emitter');
 const express = require('express');
 const async = require('async');
-const {MongoClient} = require('mongodb');
-const {URL} = require('url');
-const {ValidationError} = require('express-json-validator-middleware');
+const { MongoClient } = require('mongodb');
+const { URL } = require('url');
+const { ValidationError } = require('express-json-validator-middleware');
 const pinoHttp = require('pino-http');
 const crypto = require('crypto');
 
@@ -13,7 +13,7 @@ const crypto = require('crypto');
 const cors = require('cors');
 const bodyParser = require('body-parser');
 
-function ServiceException (path, service, message) {
+function ServiceException(path, service, message) {
   this.name = 'Service exception';
   this.message = message;
   this.path = path;
@@ -30,38 +30,32 @@ const pinoHttpDefaultOptions = {
   genReqId() {
     return crypto.randomUUID();
   }
-}
+};
 
 /**
  * @property {Db} db
  */
 class CampsiServer extends MQTTEmitter {
-  #pinoHttp;
-
-  constructor (config) {
+  constructor(config) {
     super();
     this.app = express();
     this.config = config;
-    this.#pinoHttp = pinoHttp(Object.assign(pinoHttpDefaultOptions, this.config.pino));
-    this.logger = this.#pinoHttp.logger;
+    this.pinoHttp = pinoHttp(Object.assign(pinoHttpDefaultOptions, this.config.pino));
+    this.logger = this.pinoHttp.logger;
     this.url = new URL(this.config.publicURL);
     this.services = new Map();
   }
 
-  listen () {
+  listen() {
     return this.app.listen(...arguments);
   }
 
-  mount (path, service) {
+  mount(path, service) {
     if (!/^[a-z]*$/.test(path)) {
       throw new ServiceException(path, service, 'Path is malformed');
     }
     if (!(service instanceof CampsiService)) {
-      throw new ServiceException(
-        path,
-        service,
-        'Service is not a CampsiService'
-      );
+      throw new ServiceException(path, service, 'Service is not a CampsiService');
     }
     if (this.services.has(path)) {
       throw new ServiceException(path, service, 'Path already exists');
@@ -69,7 +63,7 @@ class CampsiServer extends MQTTEmitter {
     this.services.set(path, service);
   }
 
-  start () {
+  start() {
     return this.dbConnect()
       .then(() => this.setupApp())
       .then(() => this.loadServices())
@@ -77,7 +71,7 @@ class CampsiServer extends MQTTEmitter {
       .then(() => this.finalizeSetup());
   }
 
-  dbConnect () {
+  dbConnect() {
     const campsiServer = this;
     return new Promise((resolve, reject) => {
       const mongoUri = campsiServer.config.mongo.uri;
@@ -90,7 +84,7 @@ class CampsiServer extends MQTTEmitter {
     });
   }
 
-  setupApp () {
+  setupApp() {
     this.app.use(cors());
     const bodyParserOptions = this.config.bodyParser || {
       json: {},
@@ -112,33 +106,30 @@ class CampsiServer extends MQTTEmitter {
       res.header('X-powered-by', 'campsi');
       next();
     });
-    for (let service of this.services.values()) {
-      let middlewares = service.getMiddlewares();
-      for (let middleware of middlewares) {
+    for (const service of this.services.values()) {
+      const middlewares = service.getMiddlewares();
+      for (const middleware of middlewares) {
         this.app.use(middleware(this, service));
       }
     }
     // Middlewares that augment the req object must be added before the pino middleware.
-    this.app.use(this.#pinoHttp);
+    this.app.use(this.pinoHttp);
   }
 
-  loadServices () {
+  loadServices() {
     return new Promise(resolve => {
       async.eachOf(
         this.services,
         (value, key, cb) => {
-          let path = value[0];
-          let service = value[1];
+          const path = value[0];
+          const service = value[1];
           service.server = this;
           service.db = this.db;
           service.path = path;
           service
             .initialize()
             .then(() => {
-              let serviceFullPath =
-                this.url.pathname === '/'
-                  ? '/' + path
-                  : this.url.pathname + '/' + path;
+              const serviceFullPath = this.url.pathname === '/' ? '/' + path : this.url.pathname + '/' + path;
               this.app.use(serviceFullPath, service.router);
               cb();
             })
@@ -151,9 +142,9 @@ class CampsiServer extends MQTTEmitter {
     });
   }
 
-  describe () {
+  describe() {
     this.app.get(this.url.pathname, (req, res) => {
-      let result = {
+      const result = {
         title: this.config.title,
         services: {}
       };
@@ -164,9 +155,9 @@ class CampsiServer extends MQTTEmitter {
     });
   }
 
-  finalizeSetup () {
+  finalizeSetup() {
     this.app.use((req, res, next) => {
-      res.status(404).json({message: `Can't find ${req.method} ${req.path}`});
+      res.status(404).json({ message: `Can't find ${req.method} ${req.path}` });
     });
 
     this.app.use((err, req, res, next) => {
@@ -185,7 +176,7 @@ class CampsiServer extends MQTTEmitter {
         return res.status(400).send(err.validationErrors);
       }
 
-      const {message, status} = err;
+      const { message, status } = err;
       res.status(status || 500).json({
         message,
         stack: process.env.NODE_ENV !== 'production' ? err.stack : undefined

--- a/lib/service.js
+++ b/lib/service.js
@@ -1,5 +1,4 @@
-const express = require('express');
-const {Router} = require('@awaitjs/express');
+const { Router } = require('@awaitjs/express');
 
 /**
  * Abstract class of each service mounted in campsi
@@ -16,7 +15,7 @@ class CampsiService {
    * @param   {Object}        config As defined in global configuration
    * @returns {CampsiService}        Service created
    */
-  constructor (config) {
+  constructor(config) {
     this.config = config;
     this.options = config.options;
     this.router = Router();
@@ -27,7 +26,7 @@ class CampsiService {
    * Method to extend, describe the service
    * @returns {Object} Service description
    */
-  describe () {
+  describe() {
     return {
       title: this.config.title,
       class: this.constructor.name
@@ -38,7 +37,7 @@ class CampsiService {
    * Method to extend, initialize the service
    * @returns {Promise} Return a promise, resolved when service initialization is done
    */
-  initialize () {
+  initialize() {
     return new Promise(resolve => resolve());
   }
 
@@ -46,7 +45,7 @@ class CampsiService {
    * Method to extend, should return all middlewares to include in main router
    * @returns {Array} Middlewares provided by the service
    */
-  getMiddlewares () {
+  getMiddlewares() {
     return [];
   }
 
@@ -56,7 +55,7 @@ class CampsiService {
    * @param  {*}       payload This is the payload of the event
    * @return {Boolean}         Returns true if there were any listeners called for this topic
    */
-  emit (topic, payload) {
+  emit(topic, payload) {
     topic = this.path + '/' + (topic[0] === '/' ? topic.substr(1) : topic);
     return this.server.emit(topic, payload);
   }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,13 @@
     "test-trace": "mocha \"./test/trace/*.js\" --exit",
     "test-versioned-docs": "mocha  \"./test/versioned-docs/*.js\" --exit",
     "test-stripe-billing": "mocha \"./test/stripe-billing/*.js\" --exit",
-    "test": " mocha -R dot './test/{,!(launchers)/**/}/*.js' --exit"
+    "test": " mocha -R dot './test/{,!(launchers)/**/}/*.js' --exit",
+    "prepare": "husky install"
   },
-  "eslintIgnore": ["test/data/*", "test/data"],
+  "eslintIgnore": [
+    "test/data/*",
+    "test/data"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/campsi/campsi-mono.git"
@@ -88,6 +92,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "express": "^4.16.4",
     "fake-object-id": "0.0.3",
+    "husky": "^8.0.1",
     "mime-types": "^2.1.18",
     "mocha": "^9.2.2",
     "mocha-lcov-reporter": "^1.3.0",
@@ -105,5 +110,10 @@
   "engines": {
     "node": ">=14.17.0",
     "npm": ">=7"
-  }
+  },
+  "husky": {
+    "hooks": {
+    "pre-commit": "npm run lint; npm run test"
+    }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -5,17 +5,18 @@
   "main": "index.js",
   "scripts": {
     "depcheck": "depcheck --ignores=path,mocha,mocha-lcov-reporter",
-    "lint": "./node_modules/eslint/bin/eslint.js --cache lib/** test/** index.js",
+    "lint": "eslint --no-error-on-unmatched-pattern lib/** test/**",
     "test-campsi": "mocha \"./test/campsi/*.js\" --exit",
     "test-assets": "mocha \"./test/assets/*.js\" --exit",
     "test-auth": "mocha \"./test/auth/*.js\" --exit",
     "test-docs": "mocha  \"./test/docs/*.js\" --exit",
     "test-webhooks": "mocha \"./test/webhooks/*.js\" --exit",
     "test-trace": "mocha \"./test/trace/*.js\" --exit",
-    "test-versioned-docs" :"mocha  \"./test/versioned-docs/*.js\" --exit",
-    "test-stripe-billing" : "mocha \"./test/stripe-billing/*.js\" --exit",
+    "test-versioned-docs": "mocha  \"./test/versioned-docs/*.js\" --exit",
+    "test-stripe-billing": "mocha \"./test/stripe-billing/*.js\" --exit",
     "test": " mocha -R dot './test/{,!(launchers)/**/}/*.js' --exit"
   },
+  "eslintIgnore": ["test/data/*", "test/data"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/campsi/campsi-mono.git"
@@ -48,6 +49,7 @@
     "cors": "^2.8.5",
     "crypto-js": "^3.1.9-1",
     "edit-url": "^1.0.1",
+    "eslint-plugin-n": "^15.2.0",
     "express-json-validator-middleware": "^2.2.1",
     "express-session": "^1.16.1",
     "http-errors": "^2.0.0",
@@ -82,6 +84,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-indexof": "^0.1.1",
     "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "express": "^4.16.4",
     "fake-object-id": "0.0.3",

--- a/services/assets/lib/handlers.js
+++ b/services/assets/lib/handlers.js
@@ -1,3 +1,6 @@
+/* eslint-disable node/no-unsupported-features/es-syntax */
+/* eslint-disable node/no-unsupported-features/node-builtins */
+/* eslint-disable node/no-unpublished-require */
 const debug = require('debug')('campsi:service:assets');
 const helpers = require('../../../lib/modules/responseHelpers');
 const http = require('http');
@@ -11,7 +14,7 @@ const crypto = require('crypto');
 
 const tempDir = os.tmpdir();
 
-module.exports.postAssets = function postAssets (req, res) {
+module.exports.postAssets = function postAssets(req, res) {
   // TODO create our own structure for files, be independent from multer
   serviceAsset
     .createAsset(req.service, req.files, req.user, req.headers)
@@ -25,7 +28,7 @@ module.exports.postAssets = function postAssets (req, res) {
     });
 };
 
-module.exports.copyRemote = function copyRemote (req, res, next) {
+module.exports.copyRemote = function copyRemote(req, res, next) {
   if (!req.body.url) {
     return helpers.badRequest(res, {
       message: 'Request payload must contain a `url` field'
@@ -34,9 +37,7 @@ module.exports.copyRemote = function copyRemote (req, res, next) {
   try {
     const url = new URL(req.body.url);
     const filename = url.pathname.substring(url.pathname.lastIndexOf('/') + 1);
-    const clientReportedFileExtension = filename.substring(
-      filename.lastIndexOf('.')
-    );
+    const clientReportedFileExtension = filename.substring(filename.lastIndexOf('.'));
     https.get(req.body.url, res => {
       const fileProps = {
         filename,
@@ -48,10 +49,7 @@ module.exports.copyRemote = function copyRemote (req, res, next) {
       // As a result, we can't just passthrough them to S3,
       // and we need to write them locally.
       if (!res.headers['content-length']) {
-        const tempFilePath = path.resolve(
-          tempDir,
-          `copyRemote--${crypto.randomBytes(16).toString('hex')}`
-        );
+        const tempFilePath = path.resolve(tempDir, `copyRemote--${crypto.randomBytes(16).toString('hex')}`);
         const localWriteStream = fs.createWriteStream(tempFilePath, {
           flags: 'w'
         });
@@ -128,7 +126,7 @@ module.exports.sendLocalFile = function sendLocalFile(req, res) {
   res.sendFile(path.join(req.service.options.storages.local.dataPath, req.params[0]));
 };
 
-module.exports.streamAsset = function streamAsset (req, res) {
+module.exports.streamAsset = function streamAsset(req, res) {
   if (req.storage.streamAsset) {
     return req.storage.streamAsset(req.asset).pipe(res);
   }
@@ -149,7 +147,7 @@ module.exports.streamAsset = function streamAsset (req, res) {
         newRes.pipe(res);
       }
     )
-    .on('error', function (err) {
+    .on('error', function(err) {
       debug('Streaming error: %s', err);
       res.statusCode = 500;
       res.json({
@@ -161,7 +159,7 @@ module.exports.streamAsset = function streamAsset (req, res) {
   req.pipe(newReq);
 };
 
-module.exports.getAssetMetadata = function getAssetMetadata (req, res) {
+module.exports.getAssetMetadata = function getAssetMetadata(req, res) {
   res.json(req.asset);
 };
 
@@ -169,7 +167,7 @@ module.exports.getAssetMetadata = function getAssetMetadata (req, res) {
  * @param {ExpressRequest} req
  * @param res
  */
-module.exports.deleteAsset = function deleteAsset (req, res) {
+module.exports.deleteAsset = function deleteAsset(req, res) {
   serviceAsset
     .deleteAsset(req.service, req.storage, req.asset)
     .then(result => helpers.json(res, result))

--- a/services/assets/lib/index.js
+++ b/services/assets/lib/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable node/no-unsupported-features/es-syntax */
+/* eslint-disable node/no-unpublished-require */
 const CampsiService = require('../../../lib/service');
 const helpers = require('../../../lib/modules/responseHelpers');
 const handlers = require('./handlers');
@@ -19,7 +21,7 @@ class AssetsService extends CampsiService {
     });
     this.router.param('asset', param.attachAsset);
     this.router.param('asset', param.attachStorage);
-    this.router.post('/copy', handlers.copyRemote, handlers.postAssets)
+    this.router.post('/copy', handlers.copyRemote, handlers.postAssets);
     this.router.post('/', multer().array('file'), handlers.postAssets);
     this.router.get('/', this.options.allowPublicListing ? handlers.getAssets : notAvailable);
     this.router.get('/local/*', handlers.sendLocalFile);

--- a/services/assets/lib/param.js
+++ b/services/assets/lib/param.js
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-unpublished-require */
 const helpers = require('../../../lib/modules/responseHelpers');
 const createObjectId = require('../../../lib/modules/createObjectId');
 const debug = require('debug')('campsi:services:assets');
@@ -19,9 +20,7 @@ module.exports.attachAsset = function(req, res, next, id) {
 };
 
 module.exports.attachStorage = function(req, res, next) {
-  req.storage = req.asset.storage
-    ? req.service.options.storages[req.asset.storage]
-    : req.service.options.getStorage();
+  req.storage = req.asset.storage ? req.service.options.storages[req.asset.storage] : req.service.options.getStorage();
   if (!req.storage) {
     return helpers.error(res, {
       message: 'undefined storage',

--- a/services/assets/lib/services/asset.js
+++ b/services/assets/lib/services/asset.js
@@ -1,3 +1,5 @@
+/* eslint-disable node/no-unsupported-features/es-syntax */
+/* eslint-disable node/no-unpublished-require */
 const async = require('async');
 const debug = require('debug')('campsi:service:assets');
 const paginateCursor = require('../../../../lib/modules/paginateCursor');

--- a/services/assets/lib/storage.js
+++ b/services/assets/lib/storage.js
@@ -1,15 +1,11 @@
 class AssetStorage {
-  constructor (options) {
+  constructor(options) {
     this.options = options;
   }
 
-  store () {
+  store() {}
 
-  }
-
-  deleteAsset () {
-
-  }
+  deleteAsset() {}
 }
 
 module.exports = AssetStorage;

--- a/services/assets/lib/storages/local.js
+++ b/services/assets/lib/storages/local.js
@@ -5,37 +5,41 @@ const stream = require('stream');
 const AssetStorage = require('../storage');
 
 class LocalAssetStorage extends AssetStorage {
-  get dataPath () {
+  get dataPath() {
     return this.options.dataPath;
   }
 
-  store (file) {
+  store(file) {
     return this.destination()
-      .then((destination) => {
+      .then(destination => {
         file.destination = destination;
       })
       .then(() => this.filename(file))
-      .then((filename) => {
+      .then(filename => {
         file.path = path.join(file.destination.abs, filename);
         file.url = '/local/' + file.destination.rel + '/' + filename;
         return file;
       })
       .then(() => {
-        let writingOps = [];
+        const writingOps = [];
         const writeStream = fs.createWriteStream(file.path);
         return new stream.PassThrough()
-          .on('data', (chunk) => {
-            writingOps.push(new Promise((resolve) => {
-              writeStream.write(chunk, () => {
-                resolve();
-              });
-            }));
-          }).on('finish', function () {
+          .on('data', chunk => {
+            writingOps.push(
+              new Promise(resolve => {
+                writeStream.write(chunk, () => {
+                  resolve();
+                });
+              })
+            );
+          })
+          .on('finish', function() {
             Promise.all(writingOps).then(() => {
               writeStream.destroy();
               this.emit('uploadSuccess');
             });
-          }).on('error', function () {
+          })
+          .on('error', function() {
             writeStream.destroy();
             this.emit('uploadError');
           });
@@ -43,38 +47,37 @@ class LocalAssetStorage extends AssetStorage {
   }
 
   // TODO use slang
-  filename (file) {
-    return new Promise((resolve) => {
-      fs.stat(path.join(file.destination.abs, file.originalName), function (err) {
-        resolve((err && err.code === 'ENOENT')
-          ? file.originalName
-          : Date.now() + '-' + file.originalName
-        );
+  filename(file) {
+    return new Promise(resolve => {
+      fs.stat(path.join(file.destination.abs, file.originalName), function(err) {
+        resolve(err && err.code === 'ENOENT' ? file.originalName : Date.now() + '-' + file.originalName);
       });
     });
   }
 
-  destination () {
+  destination() {
     const now = new Date();
     let month = now.getMonth() + 1;
-    month = (month < 10) ? '0' + month : month.toString();
+    month = month < 10 ? '0' + month : month.toString();
     const relativePath = now.getFullYear().toString() + '/' + month;
     const asbolutePath = path.join(this.options.dataPath, relativePath);
-    return new Promise((resolve) => {
-      mkdirp(asbolutePath, () => resolve({
-        rel: relativePath,
-        abs: asbolutePath
-      }));
+    return new Promise(resolve => {
+      mkdirp(asbolutePath, () =>
+        resolve({
+          rel: relativePath,
+          abs: asbolutePath
+        })
+      );
     });
   }
 
-  getAssetURL (asset) {
+  getAssetURL(asset) {
     return '{}{}'.format(this.options.baseUrl, asset.url);
   }
 
-  deleteAsset (file) {
+  deleteAsset(file) {
     return new Promise((resolve, reject) => {
-      fs.unlink(file.path, (err) => (err) ? reject(err) : resolve());
+      fs.unlink(file.path, err => (err ? reject(err) : resolve()));
     });
   }
 }

--- a/services/assets/lib/storages/s3.js
+++ b/services/assets/lib/storages/s3.js
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-unsupported-features/es-syntax */
 const aws = require('aws-sdk');
 const AssetStorage = require('../storage');
 const { PassThrough } = require('stream');
@@ -11,27 +12,25 @@ const debug = require('debug')('campsi:assets:s3');
  */
 
 class S3AssetStorage extends AssetStorage {
-  get dataPath () {
+  get dataPath() {
     return this.options.dataPath;
   }
 
-  store (file) {
+  store(file) {
     return new Promise(resolve => {
       resolve(this.createPassThrough(file));
     });
   }
 
-  getKey (file) {
+  getKey(file) {
     const now = new Date();
     let month = now.getMonth() + 1;
     month = month < 10 ? '0' + month : month.toString();
     const prefix = uuid();
-    return `${now.getFullYear().toString()}/${month}/${prefix}${
-      file.clientReportedFileExtension
-    }`;
+    return `${now.getFullYear().toString()}/${month}/${prefix}${file.clientReportedFileExtension}`;
   }
 
-  createPassThrough (file) {
+  createPassThrough(file) {
     const getPublicAssetURL = this.options.getPublicAssetURL;
     const s3 = new aws.S3({ ...this.options.credentials });
     const bucket = this.options.bucket;
@@ -44,10 +43,10 @@ class S3AssetStorage extends AssetStorage {
         len += chunk.length;
         buffer = Buffer.concat([buffer, chunk], len);
       })
-      .on('error', function handleError (err) {
+      .on('error', function handleError(err) {
         debug(err);
       })
-      .on('finish', function streamBuffered () {
+      .on('finish', function streamBuffered() {
         const self = this;
         s3.upload({
           Bucket: bucket,
@@ -56,7 +55,7 @@ class S3AssetStorage extends AssetStorage {
           ContentLength: file.size,
           Body: buffer
         })
-          .on('httpUploadProgress', function (ev) {
+          .on('httpUploadProgress', function(ev) {
             if (ev.total) file.uploadedSize = ev.total;
           })
           .send((err, data) => {
@@ -65,18 +64,13 @@ class S3AssetStorage extends AssetStorage {
             }
             file.s3 = data;
             file.url =
-              typeof getPublicAssetURL === 'function'
-                ? getPublicAssetURL({
-                  ...data,
-                  encodedKey: getKey(file)
-                })
-                : data.Location;
+              typeof getPublicAssetURL === 'function' ? getPublicAssetURL({ ...data, encodedKey: getKey(file) }) : data.Location;
             self.emit('uploadSuccess', file);
           });
       });
   }
 
-  deleteAsset (file) {
+  deleteAsset(file) {
     return new Promise((resolve, reject) => {
       this.s3.deleteObject(
         {
@@ -88,11 +82,11 @@ class S3AssetStorage extends AssetStorage {
     });
   }
 
-  getAssetURL (asset) {
+  getAssetURL(asset) {
     return asset.url;
   }
 
-  streamAsset (asset) {
+  streamAsset(asset) {
     const s3 = new aws.S3({ ...this.options.credentials });
     return s3
       .getObject({

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -10,14 +10,15 @@ const session = require('./middleware/session');
 const createObjectId = require('../../../lib/modules/createObjectId');
 
 module.exports = class AuthService extends CampsiService {
-  initialize () {
+  initialize() {
     this.install();
     this.prepareAuthProviders();
     this.patchRouter();
     return super.initialize();
   }
 
-  prepareAuthProviders () {
+  prepareAuthProviders() {
+    // eslint-disable-next-line array-callback-return
     Object.entries(this.options.providers).map(([name, provider]) => {
       provider.options.passReqToCallback = true;
       provider.options.scope = provider.scope;
@@ -26,15 +27,12 @@ module.exports = class AuthService extends CampsiService {
         provider.callback = local.callback;
       }
       // noinspection JSUnresolvedFunction
-      passport.use(
-        name,
-        new provider.Strategy(provider.options, passportMiddleware)
-      );
+      passport.use(name, new provider.Strategy(provider.options, passportMiddleware));
     });
   }
 
   // eslint-disable-next-line max-statements
-  patchRouter () {
+  patchRouter() {
     const router = this.router;
     const providers = this.options.providers;
     this.router.use((req, res, next) => {
@@ -62,10 +60,7 @@ module.exports = class AuthService extends CampsiService {
       router.use('/local', local.middleware(providers.local));
       router.post('/local/signup', local.signup);
       router.post('/local/signin', local.signin);
-      router.post(
-        '/local/reset-password-token',
-        local.createResetPasswordToken
-      );
+      router.post('/local/reset-password-token', local.createResetPasswordToken);
       router.post('/local/reset-password', local.resetPassword);
       router.get('/local/validate', local.validate);
     }
@@ -73,11 +68,11 @@ module.exports = class AuthService extends CampsiService {
     this.router.get('/:provider/callback', handlers.callback);
   }
 
-  getMiddlewares () {
+  getMiddlewares() {
     return [session, authUser];
   }
 
-  install () {
+  install() {
     this.db
       .collection('__users__')
       .createIndex({ email: 1 }, { unique: true })
@@ -87,7 +82,7 @@ module.exports = class AuthService extends CampsiService {
       });
   }
 
-  async fetchUsers (userIds) {
+  async fetchUsers(userIds) {
     const filter = { _id: { $in: userIds.map(id => createObjectId(id)) } };
     const users = await this.db
       .collection('__users__')

--- a/services/auth/lib/middleware/authUser.js
+++ b/services/auth/lib/middleware/authUser.js
@@ -7,29 +7,31 @@ const debug = require('debug')('campsi:auth:bearerMiddleware');
  * High order function returning the actual middleware
  * @param {CampsiServer} server
  * @returns {Function}
-*/
-module.exports = function authUser (server) {
+ */
+module.exports = function authUser(server) {
   // Initialize passport
   server.app.use(passport.initialize());
   // Middleware initialization, we register a new BearerStrategy
   const users = server.db.collection('__users__');
   // If the Authorization header contains a valid token
   // This strategy will return the associated user
-  passport.use(new BearerStrategy(function (token, done) {
-    // users "tokens" property is an object
-    // which have token as propertyName
-    // and expiration date as value
-    let query = {};
-    // expiration date is set in the future when the user signs in
-    // it's easier and more elegant to check if the exp date is "later than now"
-    query[`tokens.${token}.expiration`] = {$gt: new Date()};
-    users.findOne(query, (err, user) => {
-      if (err) {
-        debug('user findOne problem', query, err);
-      }
-      return done(null, user, {scope: 'all'});
-    });
-  }));
+  passport.use(
+    new BearerStrategy(function(token, done) {
+      // users "tokens" property is an object
+      // which have token as propertyName
+      // and expiration date as value
+      const query = {};
+      // expiration date is set in the future when the user signs in
+      // it's easier and more elegant to check if the exp date is "later than now"
+      query[`tokens.${token}.expiration`] = { $gt: new Date() };
+      users.findOne(query, (err, user) => {
+        if (err) {
+          debug('user findOne problem', query, err);
+        }
+        return done(null, user, { scope: 'all' });
+      });
+    })
+  );
 
   // Here's the actual midleware
   return (req, res, next) => {
@@ -37,7 +39,7 @@ module.exports = function authUser (server) {
     if (req.headers.authorization || req.query.access_token) {
       req.authBearerToken = req.query.access_token || req.headers.authorization.substring('Bearer '.length);
       // noinspection JSUnresolvedFunction
-      return passport.authenticate('bearer', {session: false})(req, res, next);
+      return passport.authenticate('bearer', { session: false })(req, res, next);
     }
     next();
   };

--- a/services/auth/lib/middleware/session.js
+++ b/services/auth/lib/middleware/session.js
@@ -6,7 +6,7 @@ const SessionStore = require('connect-mongodb-session')(session);
  * @param {AuthService} service
  * @returns {Function}
  */
-module.exports = function authUser (server, service) {
+module.exports = function authUser(server, service) {
   return session({
     secret: service.config.options.session.secret,
     resave: false,

--- a/services/auth/lib/modules/base64.js
+++ b/services/auth/lib/modules/base64.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('campsi');
 
-function btoa (str) {
+function btoa(str) {
   const buff = Buffer.from(str);
   let encoded;
   try {
@@ -11,7 +11,7 @@ function btoa (str) {
   return encoded;
 }
 
-function atob (str) {
+function atob(str) {
   if (!str) {
     return '';
   }
@@ -25,4 +25,4 @@ function atob (str) {
   return decoded;
 }
 
-module.exports = {atob, btoa};
+module.exports = { atob, btoa };

--- a/services/auth/lib/modules/findCallback.js
+++ b/services/auth/lib/modules/findCallback.js
@@ -1,8 +1,8 @@
-module.exports = function findCallback (args) {
+module.exports = function findCallback(args) {
   let i = 0;
   for (; i < args.length; i++) {
     if (typeof args[i] === 'function') {
-      return {callback: args[i], index: i};
+      return { callback: args[i], index: i };
     }
   }
 };

--- a/services/auth/lib/modules/queryBuilder.js
+++ b/services/auth/lib/modules/queryBuilder.js
@@ -1,8 +1,8 @@
 const { randomUUID: uuid } = require('crypto');
 
 function filterUserByEmailOrProviderId(provider, profile) {
-  let query = { $or: [] };
-  let identityIdFilter = {};
+  const query = { $or: [] };
+  const identityIdFilter = {};
   identityIdFilter['identities.' + provider.name + '.id'] = profile.identity.id;
   query.$or.push(identityIdFilter);
 
@@ -14,7 +14,7 @@ function filterUserByEmailOrProviderId(provider, profile) {
 }
 
 function genBearerToken(expiration) {
-  let exp = new Date();
+  const exp = new Date();
   exp.setTime(exp.getTime() + (expiration || 10) * 86400000);
   return {
     value: uuid(),
@@ -23,7 +23,7 @@ function genBearerToken(expiration) {
 }
 
 function genUpdate(provider, profile) {
-  let update = { $set: {} };
+  const update = { $set: {} };
   const token = genBearerToken(provider.expiration);
   update.$set.token = token.value;
   update.$set[`tokens.${token.value}`] = {
@@ -43,7 +43,7 @@ function genUpdate(provider, profile) {
  */
 function genInsert(provider, profile) {
   const token = genBearerToken(provider.expiration);
-  let insert = {
+  const insert = {
     email: profile.email.toLowerCase(),
     displayName: profile.displayName,
     picture: profile.picture,
@@ -64,8 +64,8 @@ function genInsert(provider, profile) {
 }
 
 module.exports = {
-  filterUserByEmailOrProviderId: filterUserByEmailOrProviderId,
-  genBearerToken: genBearerToken,
-  genUpdate: genUpdate,
-  genInsert: genInsert
+  filterUserByEmailOrProviderId,
+  genBearerToken,
+  genUpdate,
+  genInsert
 };

--- a/services/auth/lib/providers/facebook.js
+++ b/services/auth/lib/providers/facebook.js
@@ -11,7 +11,7 @@ const DEFAULT_EXPIRATION = 15;
  * @param {Number} [options.expiration]
  * @returns AuthProviderConfig
  */
-module.exports = function (options) {
+module.exports = function(options) {
   return {
     Strategy: require('@passport-next/passport-facebook').Strategy,
     expiration: options.expiration || DEFAULT_EXPIRATION,
@@ -29,7 +29,7 @@ module.exports = function (options) {
       profileFields: ['id', 'displayName', 'locale', 'timezone', 'email'],
       graphApiVersion: 'v3.2'
     },
-    callback: function (req, accessToken, refreshToken, profile, done) {
+    callback: function(req, accessToken, refreshToken, profile, done) {
       done(null, {
         displayName: profile._json.name,
         email: profile._json.email,

--- a/services/auth/lib/providers/github.js
+++ b/services/auth/lib/providers/github.js
@@ -8,7 +8,7 @@
  * @param {Number} options.order
  * @returns AuthProviderConfig
  */
-module.exports = function (options) {
+module.exports = function(options) {
   return {
     Strategy: require('passport-github2').Strategy,
     order: options.order,
@@ -23,7 +23,7 @@ module.exports = function (options) {
       callbackURL: options.baseUrl + '/github/callback'
     },
     scope: ['user', 'gist', 'public_repo'],
-    callback: function (req, accessToken, refreshToken, profile, done) {
+    callback: function(req, accessToken, refreshToken, profile, done) {
       // noinspection JSUnresolvedVariable
       done(null, {
         displayName: profile._json.name,

--- a/services/auth/lib/providers/google.js
+++ b/services/auth/lib/providers/google.js
@@ -8,7 +8,7 @@
  * @param {String} [options.order]
  * @returns AuthProviderConfig
  */
-module.exports = function (options) {
+module.exports = function(options) {
   return {
     Strategy: require('@passport-next/passport-google-oauth2').Strategy,
     order: options.order,
@@ -19,13 +19,13 @@ module.exports = function (options) {
     },
     title: options.title || 'Google',
     scope: ['profile', 'email'],
-    callback: function (req, accessToken, refreshToken, profile, done) {
+    callback: function(req, accessToken, refreshToken, profile, done) {
       // noinspection JSUnresolvedVariable
       done(null, {
         displayName: profile._json.name,
         email: profile.emails[0].value,
         picture: profile._json.picture,
-        identity: Object.assign({id: profile._json.sub}, profile._json)
+        identity: Object.assign({ id: profile._json.sub }, profile._json)
       });
     }
   };

--- a/services/auth/lib/providers/local.js
+++ b/services/auth/lib/providers/local.js
@@ -6,11 +6,11 @@
  * @param {Number} options.order
  * @returns AuthProviderConfig
  */
-module.exports = function (options) {
+module.exports = function(options) {
   return {
     Strategy: require('@passport-next/passport-local'),
     title: options.title,
     order: options.order,
-    options: Object.assign({verify: true}, options)
+    options: Object.assign({ verify: true }, options)
   };
 };

--- a/services/auth/lib/state.js
+++ b/services/auth/lib/state.js
@@ -1,8 +1,8 @@
 const debug = require('debug')('campsi');
 const editURL = require('edit-url');
-const {atob, btoa} = require('./modules/base64');
+const { atob, btoa } = require('./modules/base64');
 
-function getState (req) {
+function getState(req) {
   let state = {};
   let decoded;
 
@@ -25,11 +25,11 @@ module.exports.get = getState;
  * @param {ExpressRequest} req
  * @return {String} Base64 encoded JSON object
  */
-module.exports.serialize = function (req) {
-  let state = getState(req);
+module.exports.serialize = function(req) {
+  const state = getState(req);
 
   if (!state.redirectURI && req.headers.referer && !req.xhr) {
-    state.redirectURI = editURL(req.headers.referer, (urlObj) => {
+    state.redirectURI = editURL(req.headers.referer, urlObj => {
       delete urlObj.query.token;
     });
   }

--- a/services/auth/scripts/create-admin-user.js
+++ b/services/auth/scripts/create-admin-user.js
@@ -1,30 +1,38 @@
+/* eslint-disable no-process-exit */
+/* eslint-disable node/no-unpublished-require */
 const config = require('config');
 const CampsiServer = require('campsi');
 const builder = require('../lib/modules/queryBuilder');
 
-let campsi = new CampsiServer(config.campsi);
+const campsi = new CampsiServer(config.campsi);
 
 campsi.dbConnect().then(() => {
-  const collectionName = config.services['auth'].options.collectionName || '__users__';
+  const collectionName = config.services.auth.options.collectionName || '__users__';
   const collection = campsi.db.collection(collectionName);
   const email = process.argv[2] || 'admin@campsi.io';
-  let {insert, insertToken} = builder.genInsert({
-    name: 'admin',
-    expiration: 1000
-  }, {
-    email: email,
-    displayName: email,
-    identity: {}
-  });
+  const { insert, insertToken } = builder.genInsert(
+    {
+      name: 'admin',
+      expiration: 1000
+    },
+    {
+      email,
+      displayName: email,
+      identity: {}
+    }
+  );
   insert.roles = ['admin'];
-  collection.insertOne(insert).then(res => {
-    process.stdout.write('\nAdmin user created\n');
-    process.stdout.write(`  -> token : ${insertToken.value}\n`);
-    process.exit();
-  }).catch(err => {
-    process.stderr.write('\nCould not create the admin user\n');
-    process.stderr.write('  -> ' + err.message);
-    process.stderr.write('\n');
-    process.exit();
-  });
+  collection
+    .insertOne(insert)
+    .then(res => {
+      process.stdout.write('\nAdmin user created\n');
+      process.stdout.write(`  -> token : ${insertToken.value}\n`);
+      process.exit();
+    })
+    .catch(err => {
+      process.stderr.write('\nCould not create the admin user\n');
+      process.stderr.write('  -> ' + err.message);
+      process.stderr.write('\n');
+      process.exit();
+    });
 });

--- a/services/auth/scripts/debugger.js
+++ b/services/auth/scripts/debugger.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env node
+/* eslint-disable no-process-exit */
+/* eslint-disable node/no-unpublished-require */
 const argv = require('yargs').argv;
 const authKey = argv.authServiceConfigKey || 'auth';
 const email = argv.email;
@@ -9,9 +10,9 @@ const config = require('config');
 const CampsiServer = require('campsi');
 const campsi = new CampsiServer(config.campsi);
 
-function comparePassword (test, encrypted) {
+function comparePassword(test, encrypted) {
   return new Promise((resolve, reject) => {
-    bcrypt.compare(test, encrypted, function (err, isMatch) {
+    bcrypt.compare(test, encrypted, function(err, isMatch) {
       if (err) {
         reject(err);
       }
@@ -21,48 +22,48 @@ function comparePassword (test, encrypted) {
 }
 
 campsi.dbConnect().then(() => {
-  const collectionName = config.services['auth'].options.collectionName || '__users__';
+  const collectionName = config.services.auth.options.collectionName || '__users__';
   const collection = campsi.db.collection(collectionName);
   const authConfig = config.services[authKey].options;
   const salt = authConfig.providers.local.options.salt;
-  collection.findOne({
-    $or: [
-      {email: email},
-      {'identities.local.username': email}
-    ]
-  }).then(user => {
-    if (!user) {
-      debug('user not found');
-      process.exit();
-    }
-    debug('found user', user._id);
-    const decrypted = CryptoJS.AES.decrypt(user.identities.local.password, salt).toString(CryptoJS.enc.Utf8);
-    const encrypted = user.identities.local.encryptedPassword;
-    debug('decrypted password', decrypted);
-    debug('last user token', user.token);
-    if (typeof user.tokens === 'object') {
-      debug('user tokens', Object.keys(user.tokens));
-    } else {
-      debug('user tokens is not an object', user.tokens);
-    }
-
-    comparePassword(decrypted, encrypted)
-      .then(isMatch => {
-        debug(isMatch ? 'bcrypt decrypted password MATCH' : 'bcrypt decrypted password DO NOT MATCH');
-        return (argv.password) ? comparePassword(argv.password, encrypted) : null;
-      })
-      .then(isMatch => {
-        debug(isMatch ? 'bcrypt input password MATCH' : 'bcrypt input password DO NOT MATCH');
-      })
-      .then(() => {
+  collection
+    .findOne({
+      $or: [{ email }, { 'identities.local.username': email }]
+    })
+    .then(user => {
+      if (!user) {
+        debug('user not found');
         process.exit();
-      });
+      }
+      debug('found user', user._id);
+      const decrypted = CryptoJS.AES.decrypt(user.identities.local.password, salt).toString(CryptoJS.enc.Utf8);
+      const encrypted = user.identities.local.encryptedPassword;
+      debug('decrypted password', decrypted);
+      debug('last user token', user.token);
+      if (typeof user.tokens === 'object') {
+        debug('user tokens', Object.keys(user.tokens));
+      } else {
+        debug('user tokens is not an object', user.tokens);
+      }
 
-    if (user.identities.local && user.identities.local.passwordResetToken) {
-      debug('user tried to reset its password', user.identities.local.passwordResetToken);
-    }
-  }).catch(err => {
-    debug('err', err);
-    process.exit();
-  });
+      comparePassword(decrypted, encrypted)
+        .then(isMatch => {
+          debug(isMatch ? 'bcrypt decrypted password MATCH' : 'bcrypt decrypted password DO NOT MATCH');
+          return argv.password ? comparePassword(argv.password, encrypted) : null;
+        })
+        .then(isMatch => {
+          debug(isMatch ? 'bcrypt input password MATCH' : 'bcrypt input password DO NOT MATCH');
+        })
+        .then(() => {
+          process.exit();
+        });
+
+      if (user.identities.local && user.identities.local.passwordResetToken) {
+        debug('user tried to reset its password', user.identities.local.passwordResetToken);
+      }
+    })
+    .catch(err => {
+      debug('err', err);
+      process.exit();
+    });
 });

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -145,7 +145,7 @@ module.exports.getDoc = function(req, res) {
 module.exports.delDoc = function(req, res) {
   documentService
     .deleteDocument(req.resource, req.filter)
-    .then((result) => {
+    .then(result => {
       result.deletedCount === 0 ? helpers.notFound(res, result) : helpers.json(res, result);
     })
     .then(() => req.service.emit('document/deleted', getEmitPayload(req)))

--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable array-callback-return */
 const CampsiService = require('../../../lib/service');
 const param = require('./param');
 const handlers = require('./handlers');
@@ -43,23 +44,17 @@ module.exports = class DocsService extends CampsiService {
     this.router.delete('/:resource/:id', handlers.delDoc);
     this.router.delete('/:resource/:id/:state', handlers.delDoc);
     return new Promise(resolve => {
-      let ajvWriter = new Ajv({ useAssign: true });
+      const ajvWriter = new Ajv({ useAssign: true });
       csdAssign(ajvWriter);
-      let ajvReader = new Ajv({ useVisibility: true });
+      const ajvReader = new Ajv({ useVisibility: true });
       csdVisibility(ajvReader);
       async.eachOf(
         service.options.resources,
         function(resource, name, cb) {
           Object.assign(resource, service.options.classes[resource.class]);
-          resource.collection = server.db.collection(
-            'docs.{0}.{1}'.format(service.path, name)
-          );
+          resource.collection = server.db.collection('docs.{0}.{1}'.format(service.path, name));
           $RefParser
-            .dereference(
-              service.config.optionsBasePath + '/',
-              resource.schema,
-              {}
-            )
+            .dereference(service.config.optionsBasePath + '/', resource.schema, {})
             .then(function(schema) {
               resource.schema = schema;
               resource.validate = ajvWriter.compile(schema);
@@ -77,7 +72,7 @@ module.exports = class DocsService extends CampsiService {
   }
 
   describe() {
-    let desc = super.describe();
+    const desc = super.describe();
     desc.resources = {};
     desc.classes = this.options.classes;
     Object.entries(this.options.resources).map(([path, resource]) => {

--- a/services/docs/lib/modules/embedDocs.js
+++ b/services/docs/lib/modules/embedDocs.js
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-unpublished-require */
 const async = require('async');
 const ObjectId = require('mongodb').ObjectId;
 const findReferences = require('../../../../lib/modules/findReferences');

--- a/services/docs/lib/modules/permissions.js
+++ b/services/docs/lib/modules/permissions.js
@@ -48,7 +48,7 @@ module.exports.can = function can(user, resource, method, state) {
 
 module.exports.getAllowedStatesFromDocForUser = function(user, resource, method, doc) {
   const getPublicStates = () => {
-    const publicPermissions = resource.permissions['public'];
+    const publicPermissions = resource.permissions.public;
     const publicPermissionsStates = Object.keys(publicPermissions);
     return publicPermissionsStates.filter(stateName => isAllowedTo(publicPermissions[stateName], method));
   };

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -6,35 +6,21 @@ const createObjectId = require('../../../../lib/modules/createObjectId');
 const permissions = require('../modules/permissions');
 
 // Helper functions
-const getDocUsersList = doc =>
-  Object.keys(doc ? doc.users : []).map(k => doc.users[k]);
+const getDocUsersList = doc => Object.keys(doc ? doc.users : []).map(k => doc.users[k]);
 const getRequestedStatesFromQuery = (resource, query) => {
   return query.states ? query.states.split(',') : Object.keys(resource.states);
 };
 
-module.exports.getDocuments = function(
-  resource,
-  filter,
-  user,
-  query,
-  state,
-  sort,
-  pagination,
-  resources
-) {
+module.exports.getDocuments = function(resource, filter, user, query, state, sort, pagination, resources) {
   const queryBuilderOptions = {
-    resource: resource,
-    user: user,
-    query: query,
-    state: state
+    resource,
+    user,
+    query,
+    state
   };
   const filterState = {};
   filterState[`states.${state}`] = { $exists: true };
-  const dbQuery = Object.assign(
-    filterState,
-    filter,
-    builder.find(queryBuilderOptions)
-  );
+  const dbQuery = Object.assign(filterState, filter, builder.find(queryBuilderOptions));
 
   const dbFields = {
     _id: 1,
@@ -80,10 +66,7 @@ module.exports.getDocuments = function(
       {
         $addFields: {
           [`states.${state}.data`]: {
-            $mergeObjects: [
-              `$parent.states.${state}.data`,
-              `$$ROOT.states.${state}.data`
-            ]
+            $mergeObjects: [`$parent.states.${state}.data`, `$$ROOT.states.${state}.data`]
           }
         }
       }
@@ -124,7 +107,7 @@ module.exports.getDocuments = function(
     ? resource.collection.find(dbQuery, { projection: dbFields })
     : resource.collection.aggregate(pipeline);
   const requestedStates = getRequestedStatesFromQuery(resource, query);
-  let result = {};
+  const result = {};
   return new Promise((resolve, reject) => {
     paginateCursor(cursor, pagination)
       .then(info => {
@@ -142,32 +125,20 @@ module.exports.getDocuments = function(
           result.nav.next = info.page + 1;
         }
         if (sort) {
-          sortCursor(
-            cursor,
-            sort,
-            sort.indexOf('data') === 0 ? 'states.{}.data.'.format(state) : ''
-          );
+          // eslint-disable-next-line indexof/no-indexof
+          sortCursor(cursor, sort, sort.indexOf('data') === 0 ? 'states.{}.data.'.format(state) : '');
         }
         return cursor.toArray();
       })
       .then(docs => {
         result.docs = docs.map(doc => {
           const currentState = doc.states[state] || {};
-          const allowedStates = permissions.getAllowedStatesFromDocForUser(
-            user,
-            resource,
-            'GET',
-            doc
-          );
-          const states = permissions.filterDocumentStates(
-            doc,
-            allowedStates,
-            requestedStates
-          );
+          const allowedStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'GET', doc);
+          const states = permissions.filterDocumentStates(doc, allowedStates, requestedStates);
           const returnData = {
             id: doc._id,
-            state: state,
-            states: states,
+            state,
+            states,
             createdAt: currentState.createdAt,
             createdBy: currentState.createdBy,
             data: currentState.data || {}
@@ -180,13 +151,7 @@ module.exports.getDocuments = function(
           }
           return returnData;
         });
-        return embedDocs.many(
-          resource,
-          query.embed,
-          user,
-          result.docs,
-          resources
-        );
+        return embedDocs.many(resource, query.embed, user, result.docs, resources);
       })
       .then(() => {
         return resolve(result);
@@ -197,14 +162,7 @@ module.exports.getDocuments = function(
   });
 };
 
-module.exports.createDocument = function(
-  resource,
-  data,
-  state,
-  user,
-  parentId,
-  groups
-) {
+module.exports.createDocument = function(resource, data, state, user, parentId, groups) {
   return new Promise((resolve, reject) => {
     builder
       .create({
@@ -233,7 +191,7 @@ module.exports.createDocument = function(
         resource.collection.insertOne(doc, (err, result) => {
           if (err) return reject(err);
           resolve({
-            state: state,
+            state,
             id: result.insertedId,
             ...doc.states[state]
           });
@@ -249,10 +207,10 @@ module.exports.setDocument = function(resource, filter, data, state, user) {
   return new Promise((resolve, reject) => {
     builder
       .update({
-        resource: resource,
-        data: data,
-        state: state,
-        user: user
+        resource,
+        data,
+        state,
+        user
       })
       .then(update => {
         resource.collection.updateOne(filter, update, (err, result) => {
@@ -263,8 +221,8 @@ module.exports.setDocument = function(resource, filter, data, state, user) {
           }
           resolve({
             id: filter._id,
-            state: state,
-            data: data
+            state,
+            data
           });
         });
       })
@@ -284,19 +242,12 @@ module.exports.patchDocument = async (resource, filter, data, state, user) => {
 
   return {
     id: filter._id,
-    state: state,
+    state,
     data: updateDoc.value.states[state].data
   };
 };
 
-module.exports.getDocument = function(
-  resource,
-  filter,
-  query,
-  user,
-  state,
-  resources
-) {
+module.exports.getDocument = function(resource, filter, query, user, state, resources) {
   const requestedStates = getRequestedStatesFromQuery(resource, query);
   const projection = { _id: 1, states: 1, users: 1, groups: 1 };
   const match = { ...filter };
@@ -320,11 +271,9 @@ module.exports.getDocument = function(
           resource,
           user
         });
-        embedDocs
-          .one(resource, query.embed, user, returnValue.data, resources)
-          .then(doc => {
-            resolve(returnValue);
-          });
+        embedDocs.one(resource, query.embed, user, returnValue.data, resources).then(doc => {
+          resolve(returnValue);
+        });
       });
     });
   } else {
@@ -355,10 +304,7 @@ module.exports.getDocument = function(
       {
         $addFields: {
           [`states.${state}.data`]: {
-            $mergeObjects: [
-              `$parent.states.${state}.data`,
-              `$$ROOT.states.${state}.data`
-            ]
+            $mergeObjects: [`$parent.states.${state}.data`, `$$ROOT.states.${state}.data`]
           }
         }
       },
@@ -386,9 +332,7 @@ module.exports.getDocument = function(
             resource,
             user
           });
-          embedDocs
-            .one(resource, query.embed, user, returnValue.data, resources)
-            .then(doc => resolve(returnValue));
+          embedDocs.one(resource, query.embed, user, returnValue.data, resources).then(doc => resolve(returnValue));
         })
         .catch(err => {
           reject(err);
@@ -399,16 +343,12 @@ module.exports.getDocument = function(
 
 module.exports.getDocumentUsers = function(resource, filter) {
   return new Promise((resolve, reject) => {
-    resource.collection.findOne(
-      filter,
-      { projection: { users: 1 } },
-      (err, doc) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(getDocUsersList(doc));
+    resource.collection.findOne(filter, { projection: { users: 1 } }, (err, doc) => {
+      if (err) {
+        return reject(err);
       }
-    );
+      return resolve(getDocUsersList(doc));
+    });
   });
 };
 
@@ -427,18 +367,13 @@ module.exports.addUserToDocument = function(resource, filter, userDetails) {
         $set: { [`users.${userDetails.userId}`]: newUser }
       };
       const options = { returnDocument: 'after', projection: { users: 1 } };
-      resource.collection.findOneAndUpdate(
-        filter,
-        ops,
-        options,
-        (err, result) => {
-          if (err) return reject(err);
-          if (!result.value) {
-            return reject(new Error('Not Found'));
-          }
-          resolve(getDocUsersList(result.value));
+      resource.collection.findOneAndUpdate(filter, ops, options, (err, result) => {
+        if (err) return reject(err);
+        if (!result.value) {
+          return reject(new Error('Not Found'));
         }
-      );
+        resolve(getDocUsersList(result.value));
+      });
     });
   });
 };
@@ -447,18 +382,13 @@ module.exports.removeUserFromDocument = function(resource, filter, userId, db) {
   const removeUserFromDoc = new Promise((resolve, reject) => {
     const ops = { $unset: { [`users.${userId}`]: 1 } };
     const options = { returnDocument: 'after', projection: { users: 1 } };
-    resource.collection.findOneAndUpdate(
-      filter,
-      ops,
-      options,
-      (err, result) => {
-        if (err) return reject(err);
-        if (!result.value) {
-          return reject(new Error('Not Found'));
-        }
-        resolve(getDocUsersList(result.value));
+    resource.collection.findOneAndUpdate(filter, ops, options, (err, result) => {
+      if (err) return reject(err);
+      if (!result.value) {
+        return reject(new Error('Not Found'));
       }
-    );
+      resolve(getDocUsersList(result.value));
+    });
   });
   const groups = [`${resource.label}_${filter._id}`];
   const removeGroupFromUser = new Promise((resolve, reject) => {
@@ -470,18 +400,10 @@ module.exports.removeUserFromDocument = function(resource, filter, userId, db) {
     });
   });
 
-  return Promise.all([removeUserFromDoc, removeGroupFromUser]).then(
-    values => values[0]
-  );
+  return Promise.all([removeUserFromDoc, removeGroupFromUser]).then(values => values[0]);
 };
 
-module.exports.setDocumentState = function(
-  resource,
-  filter,
-  fromState,
-  toState,
-  user
-) {
+module.exports.setDocumentState = function(resource, filter, fromState, toState, user) {
   return new Promise((resolve, reject) => {
     const doSetState = function(document) {
       builder
@@ -489,8 +411,8 @@ module.exports.setDocumentState = function(
           doc: document,
           from: fromState,
           to: toState,
-          resource: resource,
-          user: user
+          resource,
+          user
         })
         .then(ops => {
           resource.collection.updateOne(filter, ops, (err, result) => {
@@ -527,22 +449,9 @@ module.exports.setDocumentState = function(
 
     resource.collection.findOne(filter, (err, document) => {
       if (err) return reject(err);
-      const allowedPutStates = permissions.getAllowedStatesFromDocForUser(
-        user,
-        resource,
-        'PUT',
-        document
-      );
-      const allowedGetStates = permissions.getAllowedStatesFromDocForUser(
-        user,
-        resource,
-        'GET',
-        document
-      );
-      if (
-        allowedPutStates.includes(toState) &&
-        allowedGetStates.includes(fromState)
-      ) {
+      const allowedPutStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'PUT', document);
+      const allowedGetStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'GET', document);
+      if (allowedPutStates.includes(toState) && allowedGetStates.includes(fromState)) {
         doSetState(document.states[fromState].data);
       } else {
         reject(new Error('Unauthorized'));
@@ -568,25 +477,17 @@ module.exports.deleteDocument = function(resource, filter) {
             if (!child.states[stateName]) {
               child.states[stateName] = docToDelete.states[stateName];
             } else {
-              child.states[stateName].data = Object.assign(
-                docToDelete.states[stateName].data,
-                child.states[stateName].data
-              );
+              child.states[stateName].data = Object.assign(docToDelete.states[stateName].data, child.states[stateName].data);
             }
             delete child.parentId;
-            if (!!docToDelete.parentId) {
+            if (docToDelete.parentId) {
               child.parentId = docToDelete.parentId;
             }
             return child;
           });
         });
 
-        await Promise.all(
-          children.map(
-            async child =>
-              await resource.collection.replaceOne({ _id: child._id }, child)
-          )
-        );
+        await Promise.all(children.map(async child => await resource.collection.replaceOne({ _id: child._id }, child)));
         await resource.collection.deleteOne(filter);
         return {};
       })
@@ -609,26 +510,17 @@ const getDocumentChildren = async (documentId, resource) => {
 const prepareGetDocument = settings => {
   const { doc, state, permissions, requestedStates, resource, user } = settings;
   const currentState = doc.states[state] || {};
-  const allowedStates = permissions.getAllowedStatesFromDocForUser(
-    user,
-    resource,
-    'GET',
-    doc
-  );
+  const allowedStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'GET', doc);
 
   return {
     id: doc._id,
-    state: state,
+    state,
     createdAt: currentState.createdAt,
     createdBy: currentState.createdBy,
     modifiedAt: currentState.modifiedAt,
     modifiedBy: currentState.modifiedBy,
     data: currentState.data || {},
     groups: doc.groups || [],
-    states: permissions.filterDocumentStates(
-      doc,
-      allowedStates,
-      requestedStates
-    )
+    states: permissions.filterDocumentStates(doc, allowedStates, requestedStates)
   };
 };

--- a/services/docs/lib/services/resource.js
+++ b/services/docs/lib/services/resource.js
@@ -1,8 +1,9 @@
+/* eslint-disable array-callback-return */
 module.exports.getResources = function(options) {
-  let result = { resources: [] };
+  const result = { resources: [] };
   Object.entries(options.resources).map(([id, resource]) => {
     result.resources.push({
-      id: id,
+      id,
       label: resource.label,
       type: resource.type,
       states: resource.states,

--- a/services/docs/lib/services/user.js
+++ b/services/docs/lib/services/user.js
@@ -1,6 +1,10 @@
-module.exports.fetchUsers = (users, options, server) => new Promise((resolve, reject) => {
-  if (typeof options.usersFetcher === 'function') {
-    return options.usersFetcher(users, server).then(users => resolve(users)).catch(err => reject(err));
-  }
-  resolve(users);
-});
+module.exports.fetchUsers = (users, options, server) =>
+  new Promise((resolve, reject) => {
+    if (typeof options.usersFetcher === 'function') {
+      return options
+        .usersFetcher(users, server)
+        .then(users => resolve(users))
+        .catch(err => reject(err));
+    }
+    resolve(users);
+  });

--- a/services/docs/scripts/migrate_owner_to_users.js
+++ b/services/docs/scripts/migrate_owner_to_users.js
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-unpublished-require */
 const config = require('config');
 const async = require('async');
 const debug = require('debug')('migrate');
@@ -7,16 +8,10 @@ const args = Array.from(process.argv).splice(2);
 const options = { services: [], params: [] };
 /* istanbul ignore if  */
 if (!module.parent) {
-  args.forEach(arg =>
-    options[arg.startsWith('--') ? 'params' : 'services'].push(arg)
-  );
+  args.forEach(arg => options[arg.startsWith('--') ? 'params' : 'services'].push(arg));
   const collections = options.services.reduce((collections, service) => {
-    const resourcesNames = Object.keys(
-      config.services[service].options.resources
-    );
-    return collections.concat(
-      resourcesNames.map(resourceName => `docs.${service}.${resourceName}`)
-    );
+    const resourcesNames = Object.keys(config.services[service].options.resources);
+    return collections.concat(resourcesNames.map(resourceName => `docs.${service}.${resourceName}`));
   }, []);
   const mongoUri = config.campsi.mongo.uri;
   MongoClient.connect(mongoUri, (err, client) => {
@@ -48,9 +43,7 @@ async function updateCollection(params, db, collection, done) {
     filter.users = { $exists: false };
   }
   try {
-    const cursor = await db
-      .collection(collection)
-      .find(filter, { projection: { ownedBy: 1, _id: 1 } });
+    const cursor = await db.collection(collection).find(filter, { projection: { ownedBy: 1, _id: 1 } });
     let cursorHasNext = true;
     const updateDocument = (doc, cb) => {
       if (doc === null) {
@@ -65,22 +58,15 @@ async function updateCollection(params, db, collection, done) {
       if (params.includes('--remove-ownedBy')) {
         ops.$unset = { ownedBy: 1 };
       }
-      db.collection(collection).updateOne(
-        { _id: doc._id },
-        ops,
-        (err, result) => {
-          err
-            ? debug('an error occured during the update', err)
-            : debug(collection, doc._id, 'nModified', result.modifiedCount);
-          cursor.hasNext((err, hasNext) => {
-            /* istanbul ignore if  */
-            if (err)
-              debug('error occured while fetching hasNext() information', err);
-            cursorHasNext = hasNext;
-            cb();
-          });
-        }
-      );
+      db.collection(collection).updateOne({ _id: doc._id }, ops, (err, result) => {
+        err ? debug('an error occured during the update', err) : debug(collection, doc._id, 'nModified', result.modifiedCount);
+        cursor.hasNext((err, hasNext) => {
+          /* istanbul ignore if  */
+          if (err) debug('error occured while fetching hasNext() information', err);
+          cursorHasNext = hasNext;
+          cb();
+        });
+      });
     };
     cursor.hasNext((err, hasNext) => {
       /* istanbul ignore if  */
@@ -108,11 +94,8 @@ async function updateCollection(params, db, collection, done) {
         done
       );
     });
-  } catch (e) {
-    return debug(
-      `an error occured during the find() from collection ${collection}`,
-      err
-    );
+  } catch (err) {
+    return debug(`an error occured during the find() from collection ${collection}`, err);
   }
 }
 

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-prototype-builtins */
 const CampsiService = require('../../../lib/service');
 const helpers = require('../../../lib/modules/responseHelpers');
 
@@ -241,7 +242,7 @@ module.exports = class StripeBillingService extends CampsiService {
    * @param {Object} params default action: set
    * @return {Object}
    */
-  createUsageRecord = async (subscriptionItemId, params) => {
+  async createUsageRecord(subscriptionItemId, params) {
     if (!params || typeof params !== 'object') {
       throw new Error('You must provide a params object');
     }
@@ -251,5 +252,5 @@ module.exports = class StripeBillingService extends CampsiService {
     params.action = params.action ?? 'set';
     params.quantity = parseInt(params.quantity);
     return await this.stripe.subscriptionItems.createUsageRecord(subscriptionItemId, params);
-  };
+  }
 };

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -12,23 +12,14 @@ const bodyToCustomer = (body, sourcePropertyName, user) => {
     tax_id_data: body.tax_id_data,
     tax_exempt: body.tax_exempt || 'none',
     address: body.address,
-    metadata: Object.assign(
-      body.metadata || {},
-      user ? { user: user._id.toString() } : {}
-    ),
+    metadata: Object.assign(body.metadata || {}, user ? { user: user._id.toString() } : {}),
     shipping: body.shipping,
-    preferred_locales: [
-      ...new Set(['fr-FR', ...(body.preferred_locales ?? [])])
-    ],
+    preferred_locales: [...new Set(['fr-FR', ...(body.preferred_locales ?? [])])],
     expand: ['tax_ids']
   };
 };
 
-const subscriptionExpand = [
-  'latest_invoice',
-  'latest_invoice.payment_intent',
-  'pending_setup_intent'
-];
+const subscriptionExpand = ['latest_invoice', 'latest_invoice.payment_intent', 'pending_setup_intent'];
 
 const optionsFromQuery = query => {
   const options = {};
@@ -63,29 +54,16 @@ module.exports = class StripeBillingService extends CampsiService {
     });
 
     this.router.post('/customers', (req, res) => {
-      stripe.customers.create(
-        bodyToCustomer(req.body, 'source', req.user),
-        defaultHandler(res)
-      );
+      stripe.customers.create(bodyToCustomer(req.body, 'source', req.user), defaultHandler(res));
     });
 
     this.router.get('/customers/:id', (req, res) => {
-      req.query.expand = [
-        ...new Set([...(req.query?.expand?.split('|') || []), 'tax_ids'])
-      ].join('|');
-      stripe.customers.retrieve(
-        req.params.id,
-        optionsFromQuery(req.query),
-        defaultHandler(res)
-      );
+      req.query.expand = [...new Set([...(req.query?.expand?.split('|') || []), 'tax_ids'])].join('|');
+      stripe.customers.retrieve(req.params.id, optionsFromQuery(req.query), defaultHandler(res));
     });
 
     this.router.put('/customers/:id', (req, res) => {
-      stripe.customers.update(
-        req.params.id,
-        bodyToCustomer(req.body, 'default_source'),
-        defaultHandler(res)
-      );
+      stripe.customers.update(req.params.id, bodyToCustomer(req.body, 'default_source'), defaultHandler(res));
     });
 
     this.router.patch('/customers/:id', (req, res) => {
@@ -101,45 +79,23 @@ module.exports = class StripeBillingService extends CampsiService {
     });
 
     this.router.get('/customers/:customer/invoices', (req, res) => {
-      stripe.invoices.list(
-        Object.assign(
-          { customer: req.params.customer },
-          optionsFromQuery(req.query)
-        ),
-        defaultHandler(res)
-      );
+      stripe.invoices.list(Object.assign({ customer: req.params.customer }, optionsFromQuery(req.query)), defaultHandler(res));
     });
 
     this.router.post('/customers/:customer/tax_ids', (req, res) => {
-      stripe.customers.createTaxId(
-        req.params.customer,
-        { type: req.body.type, value: req.body.value },
-        defaultHandler(res)
-      );
+      stripe.customers.createTaxId(req.params.customer, { type: req.body.type, value: req.body.value }, defaultHandler(res));
     });
 
     this.router.post('/customers/:customer/sources', (req, res) => {
-      stripe.customers.createSource(
-        req.params.customer,
-        { source: req.body.source },
-        defaultHandler(res)
-      );
+      stripe.customers.createSource(req.params.customer, { source: req.body.source }, defaultHandler(res));
     });
 
     this.router.delete('/customers/:customer/sources/:id', (req, res) => {
-      stripe.customers.deleteSource(
-        req.params.customer,
-        req.params.id,
-        defaultHandler(res)
-      );
+      stripe.customers.deleteSource(req.params.customer, req.params.id, defaultHandler(res));
     });
 
     this.router.delete('/customers/:customer/tax_ids/:id', (req, res) => {
-      stripe.customers.deleteTaxId(
-        req.params.customer,
-        req.params.id,
-        defaultHandler(res)
-      );
+      stripe.customers.deleteTaxId(req.params.customer, req.params.id, defaultHandler(res));
     });
 
     this.router.post('/subscriptions', (req, res) => {
@@ -160,11 +116,7 @@ module.exports = class StripeBillingService extends CampsiService {
     });
 
     this.router.get('/subscriptions/:id', (req, res) => {
-      stripe.subscriptions.retrieve(
-        req.params.id,
-        optionsFromQuery(req.query),
-        defaultHandler(res)
-      );
+      stripe.subscriptions.retrieve(req.params.id, optionsFromQuery(req.query), defaultHandler(res));
     });
 
     this.router.delete('/subscriptions/:id', (req, res) => {
@@ -197,26 +149,14 @@ module.exports = class StripeBillingService extends CampsiService {
     });
 
     this.router.get('/sources/:id', (req, res) => {
-      stripe.sources.retrieve(
-        req.params.id,
-        optionsFromQuery(req.query),
-        defaultHandler(res)
-      );
+      stripe.sources.retrieve(req.params.id, optionsFromQuery(req.query), defaultHandler(res));
     });
 
     this.router.get('/invoices/:id', (req, res) => {
-      stripe.invoices.retrieve(
-        req.params.id,
-        optionsFromQuery(req.query),
-        defaultHandler(res)
-      );
+      stripe.invoices.retrieve(req.params.id, optionsFromQuery(req.query), defaultHandler(res));
     });
     this.router.get('/payment_intents/:id', (req, res) => {
-      stripe.paymentIntents.retrieve(
-        req.params.id,
-        optionsFromQuery(req.query),
-        defaultHandler(res)
-      );
+      stripe.paymentIntents.retrieve(req.params.id, optionsFromQuery(req.query), defaultHandler(res));
     });
     this.router.post('/setup_intents', (req, res) => {
       stripe.setupIntents.create(
@@ -231,10 +171,7 @@ module.exports = class StripeBillingService extends CampsiService {
       );
     });
 
-    this.router.get(
-      '/coupons/:code[:]check-validity',
-      this.checkCouponCodeValidity
-    );
+    this.router.get('/coupons/:code[:]check-validity', this.checkCouponCodeValidity);
 
     return super.initialize();
   }
@@ -242,41 +179,39 @@ module.exports = class StripeBillingService extends CampsiService {
   fetchSubscription(subscriptionId, cb) {
     this.stripe.subscriptions.retrieve(subscriptionId, cb);
   }
+
   /**
    * @see https://stripe.com/docs/api/invoices/list
    * @param {Object} parameters can be customer, subscription, status... ex: { customer: 'cus_abc123' }
    * @return {Object}
    */
-  fetchInvoices = async parameters => {
+  async fetchInvoices(parameters) {
     const invoices = [];
     parameters = { ...parameters, limit: 100 };
     for await (const invoice of this.stripe.invoices.list(parameters)) {
       invoices.push(invoice);
     }
     return invoices;
-  };
+  }
 
   /**
    * @see https://stripe.com/docs/api/credit_notes/list
    * @param {Object} parameters can be customer, invoice... ex: { customer: 'cus_abc123' }
    * @return {Object}
    */
-  fetchCreditNotes = async parameters => {
+  async fetchCreditNotes(parameters) {
     const creditNotes = [];
     parameters = { ...parameters, limit: 100 };
     for await (const creditNote of this.stripe.creditNotes.list(parameters)) {
       creditNotes.push(creditNote);
     }
     return creditNotes;
-  };
+  }
 
-  checkCouponCodeValidity = async (req, res) => {
+  async checkCouponCodeValidity(req, res) {
     const code = req.params.code;
     if (!code) {
-      return helpers.missingParameters(
-        res,
-        new Error('code must be specified')
-      );
+      return helpers.missingParameters(res, new Error('code must be specified'));
     }
 
     const promoCodes = await this.stripe.promotionCodes.list({
@@ -296,9 +231,7 @@ module.exports = class StripeBillingService extends CampsiService {
       }
       return res.json(coupon);
     } catch (err) {
-      return res
-        .status(err.statusCode || 500)
-        .json({ message: err.raw?.message || `invalid code ${code}` });
+      return res.status(err.statusCode || 500).json({ message: err.raw?.message || `invalid code ${code}` });
     }
-  };
+  }
 };

--- a/services/trace/lib/handlers.js
+++ b/services/trace/lib/handlers.js
@@ -1,3 +1,5 @@
+/* eslint-disable space-before-function-paren */
+/* eslint-disable array-callback-return */
 const debug = require('debug')('campsi:service:trace');
 
 module.exports.traceRequest = function(req, res) {
@@ -12,8 +14,8 @@ module.exports.traceRequest = function(req, res) {
     debug('> ' + name + ': ' + value);
   });
   if (req.is('application/json')) {
-    let output = JSON.stringify(req.body, null, '  ');
-    for (let line of output.split('\n')) {
+    const output = JSON.stringify(req.body, null, '  ');
+    for (const line of output.split('\n')) {
       debug('| ' + line);
     }
   }

--- a/services/trace/lib/index.js
+++ b/services/trace/lib/index.js
@@ -1,8 +1,9 @@
+/* eslint-disable space-before-function-paren */
 const CampsiService = require('../../../lib/service');
 const handlers = require('./handlers');
 
 module.exports = class TraceService extends CampsiService {
-  initialize () {
+  initialize() {
     const service = this;
 
     this.router.use('/', (req, res, next) => {
@@ -10,11 +11,13 @@ module.exports = class TraceService extends CampsiService {
       next();
     });
     this.router.all('*', handlers.traceRequest);
-    return new Promise((resolve) => { resolve(); });
+    return new Promise(resolve => {
+      resolve();
+    });
   }
 
-  describe () {
-    let desc = super.describe();
+  describe() {
+    const desc = super.describe();
     return desc;
   }
 };

--- a/services/versioned-docs/lib/index.js
+++ b/services/versioned-docs/lib/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable array-callback-return */
 const CampsiService = require('../../../lib/service');
 const param = require('./param');
 const handlers = require('./handlers');
@@ -6,7 +7,6 @@ const $RefParser = require('json-schema-ref-parser');
 const debug = require('debug')('campsi:versioned-docs');
 const csdAssign = require('../../../lib/keywords/csdAssign');
 const csdVisibility = require('../../../lib/keywords/csdVisibility');
-const createError = require('http-errors');
 
 module.exports = class VersionedDocsService extends CampsiService {
   initialize() {
@@ -25,81 +25,46 @@ module.exports = class VersionedDocsService extends CampsiService {
     this.router.postAsync('/:resource/:id/users', handlers.postDocUser);
     this.router.deleteAsync('/:resource/:id/users/:user', handlers.delDocUser);
     this.router.getAsync('/:resource/:id/revisions/', handlers.getDocRevisions);
-    this.router.getAsync(
-      '/:resource/:id/revisions/:revision',
-      handlers.getDocRevision
-    );
-    this.router.postAsync(
-      '/:resource/:id/revisions/:revision[:]set-as-version',
-      handlers.setDocVersion
-    );
+    this.router.getAsync('/:resource/:id/revisions/:revision', handlers.getDocRevision);
+    this.router.postAsync('/:resource/:id/revisions/:revision[:]set-as-version', handlers.setDocVersion);
     this.router.getAsync('/:resource/:id/versions/', handlers.getDocVersions);
-    this.router.getAsync(
-      '/:resource/:id/versions/:version',
-      handlers.getDocVersion
-    );
+    this.router.getAsync('/:resource/:id/versions/:version', handlers.getDocVersion);
     this.router.getAsync('/:resource/:id', handlers.getDoc);
     this.router.postAsync('/:resource', handlers.postDoc);
     this.router.patchAsync('/:resource/:id', handlers.updateDoc);
     this.router.deleteAsync('/:resource/:id', handlers.delDoc);
 
-    let ajvWriter = new Ajv({ useAssign: true });
+    const ajvWriter = new Ajv({ useAssign: true });
     csdAssign(ajvWriter);
-    let ajvReader = new Ajv({ useVisibility: true });
+    const ajvReader = new Ajv({ useVisibility: true });
     csdVisibility(ajvReader);
     try {
       return Promise.all(
-        Object.entries(service.options.resources).map(
-          async ([resName, resource]) => {
-            resource = {
-              ...resource,
-              ...service.options.classes[resource.class]
-            };
-            ['current', 'revision', 'version'].map(col => {
-              resource[`${col}Collection`] = server.db.collection(
-                `${service.options.dbPrefix}.${resName}-${col}`
-              );
-            });
-            const relIndexes = Object.entries(resource.rels || {}).map(
-              ([name, rel]) => {
-                return { key: { [`${rel.path}`]: 1 } };
-              }
-            );
-            await resource.currentCollection.createIndexes([
-              { key: { 'users.$**': 1 } },
-              { key: { revision: 1 } },
-              ...relIndexes
-            ]);
+        Object.entries(service.options.resources).map(async ([resName, resource]) => {
+          resource = {
+            ...resource,
+            ...service.options.classes[resource.class]
+          };
+          ['current', 'revision', 'version'].map(col => {
+            resource[`${col}Collection`] = server.db.collection(`${service.options.dbPrefix}.${resName}-${col}`);
+          });
+          const relIndexes = Object.entries(resource.rels || {}).map(([, rel]) => {
+            return { key: { [`${rel.path}`]: 1 } };
+          });
+          await resource.currentCollection.createIndexes([{ key: { 'users.$**': 1 } }, { key: { revision: 1 } }, ...relIndexes]);
 
-            await resource.revisionCollection.createIndex(
-              { currentId: 1, revision: 1 },
-              { unique: true }
-            );
+          await resource.revisionCollection.createIndex({ currentId: 1, revision: 1 }, { unique: true });
 
-            await resource.versionCollection.createIndex(
-              { currentId: 1, version: 1 },
-              { unique: true }
-            );
-            await resource.versionCollection.createIndex(
-              { currentId: 1, revision: 1 },
-              { unique: true }
-            );
-            await resource.versionCollection.createIndex(
-              { currentId: 1, tag: 1 },
-              { unique: true }
-            );
+          await resource.versionCollection.createIndex({ currentId: 1, version: 1 }, { unique: true });
+          await resource.versionCollection.createIndex({ currentId: 1, revision: 1 }, { unique: true });
+          await resource.versionCollection.createIndex({ currentId: 1, tag: 1 }, { unique: true });
 
-            const schema = await $RefParser.dereference(
-              service.config.optionsBasePath + '/',
-              resource.schema,
-              {}
-            );
-            resource.schema = schema;
-            resource.validate = ajvWriter.compile(schema);
-            resource.filter = ajvReader.compile(schema);
-            return (service.options.resources[`${resName}`] = resource);
-          }
-        )
+          const schema = await $RefParser.dereference(service.config.optionsBasePath + '/', resource.schema, {});
+          resource.schema = schema;
+          resource.validate = ajvWriter.compile(schema);
+          resource.filter = ajvReader.compile(schema);
+          return (service.options.resources[`${resName}`] = resource);
+        })
       );
     } catch (e) {
       debug(e);
@@ -107,7 +72,7 @@ module.exports = class VersionedDocsService extends CampsiService {
   }
 
   describe() {
-    let desc = super.describe();
+    const desc = super.describe();
     desc.resources = {};
     desc.classes = this.options.classes;
     Object.entries(this.options.resources).map(([path, resource]) => {

--- a/services/versioned-docs/lib/modules/permissions.js
+++ b/services/versioned-docs/lib/modules/permissions.js
@@ -6,10 +6,10 @@ const PUBLIC_ERR_MESSAGE = 'resource is not public for this method';
 
 module.exports.can = function can(user, resource, method) {
   if (typeof user === 'undefined') {
-    if (!resource.permissions['public']) {
+    if (!resource.permissions.public) {
       throw new Error(PUBLIC_ERR_MESSAGE);
     }
-    const publicPermissions = resource.permissions['public'];
+    const publicPermissions = resource.permissions.public;
     const publicIsAllowed = isAllowedTo(publicPermissions, method);
     if (!publicIsAllowed) {
       throw new Error(PUBLIC_ERR_MESSAGE);

--- a/services/versioned-docs/lib/modules/queryBuilder.js
+++ b/services/versioned-docs/lib/modules/queryBuilder.js
@@ -1,3 +1,4 @@
+/* eslint-disable array-callback-return */
 const debug = require('debug')('campsi:service:versioned-docs');
 const createObjectId = require('../../../../lib/modules/createObjectId');
 /**
@@ -11,9 +12,7 @@ const validate = async (resource, doc) => {
     return true;
   } else {
     debug('model have %d error(s)', resource.validate.errors.length);
-    throw new Error(
-      resource.validate.errors.map(e => `${e.dataPath} ${e.message}`).join(', ')
-    );
+    throw new Error(resource.validate.errors.map(e => `${e.dataPath} ${e.message}`).join(', '));
   }
 };
 
@@ -34,13 +33,11 @@ const buildRelsId = (resource, doc) => {
 };
 
 module.exports.find = function find(options) {
-  let filter = {};
+  const filter = {};
   if (options.query) {
-    const relsPath = Object.entries(options.resource.rels || []).map(
-      ([name, rel]) => {
-        return rel.path;
-      }
-    );
+    const relsPath = Object.entries(options.resource.rels || []).map(([name, rel]) => {
+      return rel.path;
+    });
     Object.entries(options.query).map(([prop, val]) => {
       if (prop.startsWith('data.')) {
         prop = prop.slice(5);

--- a/services/versioned-docs/lib/param.js
+++ b/services/versioned-docs/lib/param.js
@@ -1,9 +1,6 @@
-const helpers = require('../../../lib/modules/responseHelpers');
 const createObjectId = require('../../../lib/modules/createObjectId');
 const { can } = require('./modules/permissions');
-const {
-  getValidGroupsFromString
-} = require('../../../lib/modules/groupsHelpers');
+const { getValidGroupsFromString } = require('../../../lib/modules/groupsHelpers');
 const createError = require('http-errors');
 
 module.exports.attachResource = function(options) {
@@ -16,23 +13,18 @@ module.exports.attach = (req, res, next, options) => {
   if (req.params.resource) {
     req.resource = options.resources[req.params.resource];
 
-    if (!req.resource)
-      throw new createError.NotFound(
-        `Resource ${req.params.resource} not found`
-      );
+    if (!req.resource) throw new createError.NotFound(`Resource ${req.params.resource} not found`);
 
     if (req.params.id) {
       req.filter = { _id: createObjectId(req.params.id) };
-      if (!req.filter._id)
+      if (!req.filter._id) {
         throw new createError.BadRequest("Can't recognize proper id");
+      }
     }
 
-    req.groups = req.query?.groups
-      ? getValidGroupsFromString(req.query.groups)
-      : [];
+    req.groups = req.query?.groups ? getValidGroupsFromString(req.query.groups) : [];
 
     // USER can access RESOURCE/FILTER with METHOD?
-
     try {
       const filter = can(req.user, req.resource, req.method);
       req.filter = { ...req.filter, ...filter };

--- a/services/versioned-docs/lib/services/resource.js
+++ b/services/versioned-docs/lib/services/resource.js
@@ -1,9 +1,10 @@
+/* eslint-disable array-callback-return */
 module.exports.getResources = function(options) {
-  let result = { resources: [] };
+  const result = { resources: [] };
   result.classes = options.classes;
   Object.entries(options.resources).map(([id, resource]) => {
     result.resources.push({
-      id: id,
+      id,
       label: resource.label,
       type: resource.type,
       states: resource.states,

--- a/services/versioned-docs/lib/services/user.js
+++ b/services/versioned-docs/lib/services/user.js
@@ -1,8 +1,6 @@
 module.exports.fetchUsers = async (users, options, server) => {
   if (typeof options.usersFetcher !== 'function') {
-    throw new Error(
-      'usersFetcher should be defined as a function in service options'
-    );
+    throw new Error('usersFetcher should be defined as a function in service options');
   }
   return await options.usersFetcher(users, server);
 };

--- a/test/assets/assets.js
+++ b/test/assets/assets.js
@@ -24,7 +24,7 @@ const services = {
 };
 
 describe('Assets API', () => {
-  let context = {};
+  const context = {};
   beforeEach(setupBeforeEach(config, services, context));
   afterEach(done => {
     context.server.close(done);
@@ -32,15 +32,14 @@ describe('Assets API', () => {
 
   function createAsset(source) {
     return new Promise(function(resolve, reject) {
-      const localStorage = context.campsi.services.get('assets').config.options
-        .storages.local;
+      const localStorage = context.campsi.services.get('assets').config.options.storages.local;
       const originalName = path.basename(source);
       const storageName = uniqueSlug('');
       const stats = fs.statSync(source);
 
-      let file = {
+      const file = {
         fieldName: 'file',
-        originalName: originalName,
+        originalName,
         clientReportedMimeType: mime.lookup(source),
         clientReportedFileExtension: path.extname(source),
         path: '',
@@ -91,7 +90,7 @@ describe('Assets API', () => {
             .then(cb)
             .catch(err => {
               if (err) {
-                process.exit(1);
+                throw new Error("Can't create asset");
               }
               cb();
             });
@@ -108,24 +107,22 @@ describe('Assets API', () => {
    */
   describe('/GET/', () => {
     it.skip('it should return a list of assets', done => {
-      createAssets(Array(5).fill('../rsrc/logo_agilitation.png')).then(
-        () => {
-          chai
-            .request(context.campsi.app)
-            .get('/assets/')
-            // .query({ page: 3, perPage: 2 })
-            .end((err, res) => {
-              if (err) debug(`received an error from chai: ${err.message}`);
-              res.should.have.status(200);
-              res.should.have.header('x-total-count', '5');
-              res.should.have.header('link');
-              res.should.be.json;
-              res.body.should.be.an('array');
-              res.body.length.should.be.eq(1);
-              done();
-            });
-        }
-      );
+      createAssets(Array(5).fill('../rsrc/logo_agilitation.png')).then(() => {
+        chai
+          .request(context.campsi.app)
+          .get('/assets/')
+          // .query({ page: 3, perPage: 2 })
+          .end((err, res) => {
+            if (err) debug(`received an error from chai: ${err.message}`);
+            res.should.have.status(200);
+            res.should.have.header('x-total-count', '5');
+            res.should.have.header('link');
+            res.should.be.json;
+            res.body.should.be.an('array');
+            res.body.length.should.be.eq(1);
+            done();
+          });
+      });
     });
   });
   /*
@@ -138,8 +135,7 @@ describe('Assets API', () => {
         .request(context.campsi.app)
         .post('/assets/copy')
         .send({
-          url:
-            'https://uploads-ssl.webflow.com/5d5f94b1c701ded9b6298526/5d5f994938c00e4777ad545a_Logo-axeptio-galet_500.png'
+          url: 'https://uploads-ssl.webflow.com/5d5f94b1c701ded9b6298526/5d5f994938c00e4777ad545a_Logo-axeptio-galet_500.png'
         })
         .end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);
@@ -157,11 +153,7 @@ describe('Assets API', () => {
       chai
         .request(context.campsi.app)
         .post('/assets')
-        .attach(
-          'file',
-          fs.readFileSync('./test/rsrc/logo_agilitation.png'),
-          'logo_agilitation.png'
-        )
+        .attach('file', fs.readFileSync('./test/rsrc/logo_agilitation.png'), 'logo_agilitation.png')
         .end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);
           res.should.have.status(200);

--- a/test/auth/auth-fetch-users.js
+++ b/test/auth/auth-fetch-users.js
@@ -41,7 +41,7 @@ function createUser(campsi, user) {
 }
 
 describe('User Fetching', () => {
-  let context = {};
+  const context = {};
   beforeEach(setupBeforeEach(config, services, context));
   afterEach(done => context.server.close(done));
   describe('AuthService.fetchUsers', () => {

--- a/test/auth/auth-local-password-reset.js
+++ b/test/auth/auth-local-password-reset.js
@@ -28,29 +28,35 @@ const services = {
   Assets: require('../../services/assets/lib')
 };
 
-const signin = (chai, campsi, username, password) => chai.request(campsi.app)
-  .post('/auth/local/signin')
-  .send({username: username, password: password});
+const signin = (chai, campsi, username, password) =>
+  chai
+    .request(campsi.app)
+    .post('/auth/local/signin')
+    .send({ username, password });
 
-const createResetPasswordToken = (chai, campsi, email) => chai.request(campsi.app)
-  .post('/auth/local/reset-password-token')
-  .send({email: email});
+const createResetPasswordToken = (chai, campsi, email) =>
+  chai
+    .request(campsi.app)
+    .post('/auth/local/reset-password-token')
+    .send({ email });
 
-const resetUserPassword = (chai, campsi, username, passwordResetToken, newPassword) => chai.request(campsi.app)
-  .post('/auth/local/reset-password')
-  .send({
-    username: username,
-    token: passwordResetToken,
-    password: newPassword
-  });
+const resetUserPassword = (chai, campsi, username, passwordResetToken, newPassword) =>
+  chai
+    .request(campsi.app)
+    .post('/auth/local/reset-password')
+    .send({
+      username,
+      token: passwordResetToken,
+      password: newPassword
+    });
 
 describe('Auth Local Password Reset', () => {
-  let context = {};
+  const context = {};
   beforeEach(setupBeforeEach(config, services, context));
   afterEach(done => context.server.close(done));
   /*
-     * Test the /GET local/validate route
-     */
+   * Test the /GET local/validate route
+   */
   describe('/GET local/reset password [default]', () => {
     it('it should validate the user', done => {
       const campsi = context.campsi;
@@ -71,13 +77,12 @@ describe('Auth Local Password Reset', () => {
       });
 
       createUser(chai, campsi, glenda).then(() => {
-        createResetPasswordToken(chai, campsi, glenda.email)
-          .end((err, res) => {
-            if (err) debug(`received an error from chai: ${err.message}`);
-            res.should.have.status(200);
-            res.should.be.json;
-            res.body.should.be.a('object');
-          });
+        createResetPasswordToken(chai, campsi, glenda.email).end((err, res) => {
+          if (err) debug(`received an error from chai: ${err.message}`);
+          res.should.have.status(200);
+          res.should.be.json;
+          res.body.should.be.a('object');
+        });
       });
     });
   });

--- a/test/auth/auth-local.js
+++ b/test/auth/auth-local.js
@@ -42,7 +42,7 @@ function createUser(campsi, user) {
 }
 
 describe('Auth Local API', () => {
-  let context = {};
+  const context = {};
   beforeEach(setupBeforeEach(config, services, context));
   afterEach(done => context.server.close(done));
   /*
@@ -199,9 +199,7 @@ describe('Auth Local API', () => {
                   const toURL = encodeURIComponent;
                   let validateUrl = '/auth/local/validate';
                   validateUrl += '?token=' + toURL(signupPayload.token);
-                  validateUrl +=
-                    '&redirectURI=' +
-                    toURL('/trace/local-signup-validate-redirect');
+                  validateUrl += '&redirectURI=' + toURL('/trace/local-signup-validate-redirect');
                   chai
                     .request(campsi.app)
                     .get(validateUrl)
@@ -217,8 +215,7 @@ describe('Auth Local API', () => {
                       password: 'signup!'
                     })
                     .end((err, res) => {
-                      if (err)
-                        debug(`received an error from chai: ${err.message}`);
+                      if (err) debug(`received an error from chai: ${err.message}`);
                       res.should.have.status(200);
                       signinToken = res.body.token;
                       serieCb();

--- a/test/auth/auth-unit.js
+++ b/test/auth/auth-unit.js
@@ -1,7 +1,7 @@
 const chai = require('chai');
 const { atob, btoa } = require('../../services/auth/lib/modules/base64');
 
-let assert = chai.assert;
+const assert = chai.assert;
 
 describe('Unit Test', () => {
   describe('Module base 64', () => {

--- a/test/auth/auth.js
+++ b/test/auth/auth.js
@@ -11,7 +11,7 @@ const { btoa } = require('../../services/auth/lib/modules/base64');
 const createUser = require('../helpers/createUser');
 const debug = require('debug')('campsi:test');
 const setupBeforeEach = require('../helpers/setupBeforeEach');
-let expect = chai.expect;
+const expect = chai.expect;
 format.extend(String.prototype);
 chai.use(chaiHttp);
 chai.should();
@@ -30,7 +30,7 @@ const services = {
 };
 
 describe('Auth API', () => {
-  let context = {};
+  const context = {};
   beforeEach(setupBeforeEach(config, services, context));
   afterEach(done => {
     context.server.close(done);
@@ -149,7 +149,7 @@ describe('Auth API', () => {
             res.body.should.be.a('object');
             res.body.should.have.property('message');
             // bdd token must be undefined
-            let filter = {};
+            const filter = {};
             filter['token.value'] = token;
             campsi.db
               .collection('__users__')
@@ -172,7 +172,7 @@ describe('Auth API', () => {
     it('it shoud redirect on /me page on successful connection', done => {
       const campsi = context.campsi;
       createUser(chai, campsi, glenda).then(() => {
-        let state = btoa(
+        const state = btoa(
           JSON.stringify({
             redirectURI: '/auth/me'
           })
@@ -292,11 +292,7 @@ describe('Auth API', () => {
       createUser(chai, campsi, admin, true).then(adminToken => {
         campsi.db
           .collection('__users__')
-          .findOneAndUpdate(
-            { email: admin.email },
-            { $set: { isAdmin: true } },
-            { returnDocument: 'after' }
-          )
+          .findOneAndUpdate({ email: admin.email }, { $set: { isAdmin: true } }, { returnDocument: 'after' })
           .then(updateResult => {
             createUser(chai, campsi, glenda).then(userToken => {
               chai
@@ -312,14 +308,13 @@ describe('Auth API', () => {
                   res.body.should.be.a('array');
                   res.body.length.should.be.equal(2);
                   // glenda
-                  const userId = res.body.filter(
-                    u => u.email === glenda.email
-                  )[0]._id;
+                  const userId = res.body.filter(u => u.email === glenda.email)[0]._id;
                   chai
                     .request(campsi.app)
                     .get(`/auth/users/${userId}/access_token`)
                     .set('Authorization', `Bearer ${adminToken}`)
                     .end((err, res) => {
+                      debug(err);
                       debug(res.body);
                       res.should.have.status(200);
                       res.body.should.have.property('token');
@@ -333,7 +328,6 @@ describe('Auth API', () => {
   });
 
   describe('invitation', () => {
-    
     it('should create a new user', done => {
       const campsi = context.campsi;
       createUser(chai, campsi, glenda, true).then(token => {
@@ -384,15 +378,12 @@ describe('Auth API', () => {
               res.should.be.a('object');
               res.body.should.have.property('id');
               debug(res.body);
-              campsi.db
-                .collection('__users__')
-                .findOne({ email: robert.email }, (err, doc) => {
-                  if (err)
-                    return debug(`received an error from chai: ${err.message}`);
-                  doc.should.be.a('object');
-                  res.body.id.should.be.eq(doc._id.toString());
-                  done();
-                });
+              campsi.db.collection('__users__').findOne({ email: robert.email }, (err, doc) => {
+                if (err) return debug(`received an error from chai: ${err.message}`);
+                doc.should.be.a('object');
+                res.body.id.should.be.eq(doc._id.toString());
+                done();
+              });
             });
         });
     });
@@ -421,8 +412,7 @@ describe('Auth API', () => {
               data: { projectId: 'testProjectId' }
             })
             .end((err, res) => {
-              if (err)
-                return debug(`received an error from chai: ${err.message}`);
+              if (err) return debug(`received an error from chai: ${err.message}`);
               const invitationToken = res.body.invitationToken;
               chai
                 .request(campsi.app)
@@ -441,10 +431,7 @@ describe('Auth API', () => {
                   .post(`/auth/invitations/${invitationToken.value}`)
                   .set('Authorization', 'Bearer ' + glendaToken)
                   .end((err, res) => {
-                    if (err)
-                      return debug(
-                        `received an error from chai: ${err.message}`
-                      );
+                    if (err) return debug(`received an error from chai: ${err.message}`);
                     res.should.have.status(404);
                     done();
                   });

--- a/test/auth/utils/initialization.js
+++ b/test/auth/utils/initialization.js
@@ -1,4 +1,4 @@
-const {MongoClient} = require('mongodb');
+const { MongoClient } = require('mongodb');
 const mongoUriBuilder = require('mongo-uri-builder');
 const CampsiServer = require('campsi');
 const debug = require('debug')('campsi-test');
@@ -9,8 +9,8 @@ format.extend(String.prototype);
 chai.use(chaiHttp);
 chai.should();
 
-module.exports = function initialize (config, services) {
-  let campsi = new CampsiServer(config.campsi);
+module.exports = function initialize(config, services) {
+  const campsi = new CampsiServer(config.campsi);
   Object.keys(services).forEach(service => {
     campsi.mount(service, new services[service](config.services[service]));
   });
@@ -20,21 +20,21 @@ module.exports = function initialize (config, services) {
   campsi.start();
   return {
     campsi,
-    beforeEachCallback: (done) => {
+    beforeEachCallback: done => {
       // Empty the database
       const mongoUri = mongoUriBuilder(config.campsi.mongo);
       MongoClient.connect(mongoUri, (err, client) => {
         if (err) {
           debug('Error during the mongo connection', err);
         }
-        let db = client.db(config.campsi.mongo.database);
+        const db = client.db(config.campsi.mongo.database);
         db.dropDatabase(() => {
           client.close();
           done();
         });
       });
     },
-    afterCallback: (done) => {
+    afterCallback: done => {
       campsi.server.close();
       done();
     }

--- a/test/campsi/errors.js
+++ b/test/campsi/errors.js
@@ -13,42 +13,50 @@ chai.use(chaiHttp);
 format.extend(String.prototype);
 chai.should();
 
-let errors = [{
-  describe: '400 Bad Request',
-  function: 'badRequest',
-  code: 400
-}, {
-  describe: '401 Unauthorized',
-  function: 'unauthorized',
-  code: 401
-}, {
-  describe: '403 Forbidden',
-  function: 'forbidden',
-  code: 403
-}, {
-  describe: '404 Not Found',
-  function: 'notFound',
-  code: 404
-}, {
-  describe: '501 Not Implemented',
-  function: 'notImplemented',
-  code: 501
-}, {
-  describe: '503 Service Not Available',
-  function: 'serviceNotAvailable',
-  code: 503
-}];
+const errors = [
+  {
+    describe: '400 Bad Request',
+    function: 'badRequest',
+    code: 400
+  },
+  {
+    describe: '401 Unauthorized',
+    function: 'unauthorized',
+    code: 401
+  },
+  {
+    describe: '403 Forbidden',
+    function: 'forbidden',
+    code: 403
+  },
+  {
+    describe: '404 Not Found',
+    function: 'notFound',
+    code: 404
+  },
+  {
+    describe: '501 Not Implemented',
+    function: 'notImplemented',
+    code: 501
+  },
+  {
+    describe: '503 Service Not Available',
+    function: 'serviceNotAvailable',
+    code: 503
+  }
+];
 
-describe('Errors Test', function () {
-  errors.forEach((error) => {
-    describe(error.describe, function () {
-      it('should return the correct message, no stack', function (done) {
-        let app = express();
+describe('Errors Test', function() {
+  errors.forEach(error => {
+    describe(error.describe, function() {
+      it('should return the correct message, no stack', function(done) {
+        const app = express();
         process.env.CAMPSI_DEBUG = 0;
-        app.get('/errorPath', function (req, res) {
+        app.get('/errorPath', function(req, res) {
           responseHelpers[error.function](res, new Error('Test Error'));
         });
-        chai.request(app)
+        chai
+          .request(app)
           .get('/errorPath')
           .end((err, res) => {
             if (err) debug(`received an error from chai: ${err.message}`);
@@ -61,13 +69,14 @@ describe('Errors Test', function () {
             done();
           });
       });
-      it('should return the correct message & stack', function (done) {
-        let app = express();
+      it('should return the correct message & stack', function(done) {
+        const app = express();
         process.env.CAMPSI_DEBUG = 1;
-        app.get('/errorPath', function (req, res) {
+        app.get('/errorPath', function(req, res) {
           responseHelpers[error.function](res, new Error('Test Error'));
         });
-        chai.request(app)
+        chai
+          .request(app)
           .get('/errorPath')
           .end((err, res) => {
             if (err) debug(`received an error from chai: ${err.message}`);

--- a/test/campsi/modules.js
+++ b/test/campsi/modules.js
@@ -18,10 +18,10 @@ const { URL } = require('url');
 describe('Modules Test', function() {
   describe('buildLink module', function() {
     it('should return the correct url', function(done) {
-      var app = express();
+      const app = express();
 
       app.get('/test', function(req, res) {
-        let url = buildLink(req, 2, ['foo', 'unknown']);
+        const url = buildLink(req, 2, ['foo', 'unknown']);
         res.json(url);
         res.end();
       });
@@ -32,7 +32,7 @@ describe('Modules Test', function() {
         .end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);
           res.should.have.status(200);
-          let url = new URL(res.body);
+          const url = new URL(res.body);
           url.should.have.property('pathname');
           url.pathname.should.equal('/test');
           url.should.have.property('searchParams');

--- a/test/campsi/prefix.js
+++ b/test/campsi/prefix.js
@@ -17,17 +17,17 @@ let campsi;
 let server;
 
 class TestService extends CampsiService {
-  initialize () {
-    this.router.get('/', function (req, res) {
+  initialize() {
+    this.router.get('/', function(req, res) {
       res.json('true');
     });
     return super.initialize();
   }
 }
 
-describe('Prefix Test', function () {
-  describe('Testing without prefix', function () {
-    beforeEach((done) => {
+describe('Prefix Test', function() {
+  describe('Testing without prefix', function() {
+    beforeEach(done => {
       campsi = new CampsiServer(config.campsi);
       campsi.mount('test', new TestService(config.services.test));
 
@@ -36,19 +36,19 @@ describe('Prefix Test', function () {
         done();
       });
 
-      campsi.start()
-        .catch((err) => {
-          debug('Error: %s', err);
-        });
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
 
-    afterEach((done) => {
+    afterEach(done => {
       server.close();
       done();
     });
 
-    it('Describe must works', function (done) {
-      chai.request(campsi.app)
+    it('Describe must works', function(done) {
+      chai
+        .request(campsi.app)
         .get('/')
         .end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);
@@ -58,8 +58,9 @@ describe('Prefix Test', function () {
         });
     });
 
-    it('Service must works', function (done) {
-      chai.request(campsi.app)
+    it('Service must works', function(done) {
+      chai
+        .request(campsi.app)
         .get('/test')
         .end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);
@@ -70,8 +71,8 @@ describe('Prefix Test', function () {
     });
   });
 
-  describe('Testing with a prefix', function () {
-    beforeEach((done) => {
+  describe('Testing with a prefix', function() {
+    beforeEach(done => {
       campsi = new CampsiServer(config.campsiPrefix);
       campsi.mount('test', new TestService(config.services.test));
 
@@ -80,19 +81,19 @@ describe('Prefix Test', function () {
         done();
       });
 
-      campsi.start()
-        .catch((err) => {
-          debug('Error: %s', err);
-        });
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
 
-    afterEach((done) => {
+    afterEach(done => {
       server.close();
       done();
     });
 
-    it('Root query must failed', function (done) {
-      chai.request(campsi.app)
+    it('Root query must failed', function(done) {
+      chai
+        .request(campsi.app)
         .get('/')
         .end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);
@@ -100,8 +101,9 @@ describe('Prefix Test', function () {
           done();
         });
     });
-    it('Describe must works', function (done) {
-      chai.request(campsi.app)
+    it('Describe must works', function(done) {
+      chai
+        .request(campsi.app)
         .get('/v1')
         .end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);
@@ -111,8 +113,9 @@ describe('Prefix Test', function () {
           done();
         });
     });
-    it('Service must works', function (done) {
-      chai.request(campsi.app)
+    it('Service must works', function(done) {
+      chai
+        .request(campsi.app)
         .get('/v1/test')
         .end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);

--- a/test/campsi/services.js
+++ b/test/campsi/services.js
@@ -12,15 +12,15 @@ const config = require('config');
 chai.use(chaiHttp);
 format.extend(String.prototype);
 chai.should();
-let assert = chai.assert;
+const assert = chai.assert;
 
 class TestService extends CampsiService {}
 class TestClass {}
 
-describe('Services Test', function () {
-  describe('mount  one module', function () {
-    it('it should work', function (done) {
-      let campsi = new CampsiServer(config.campsi);
+describe('Services Test', function() {
+  describe('mount  one module', function() {
+    it('it should work', function(done) {
+      const campsi = new CampsiServer(config.campsi);
       let passed = true;
       try {
         campsi.mount('test', new TestService(config.services.test));
@@ -33,9 +33,9 @@ describe('Services Test', function () {
     });
   });
 
-  describe('mount on an invalid path', function () {
-    it('it should not work if path is invalid', function (done) {
-      let campsi = new CampsiServer(config.campsi);
+  describe('mount on an invalid path', function() {
+    it('it should not work if path is invalid', function(done) {
+      const campsi = new CampsiServer(config.campsi);
       let passed = false;
       try {
         campsi.mount('t3st', new TestService(config.services.test));
@@ -48,9 +48,9 @@ describe('Services Test', function () {
     });
   });
 
-  describe('mount an invalid service', function () {
-    it('it should not work if service is invalid', function (done) {
-      let campsi = new CampsiServer(config.campsi);
+  describe('mount an invalid service', function() {
+    it('it should not work if service is invalid', function(done) {
+      const campsi = new CampsiServer(config.campsi);
       let passed = false;
       try {
         campsi.mount('test', new TestClass(config.services.test));
@@ -63,9 +63,9 @@ describe('Services Test', function () {
     });
   });
 
-  describe('mount two modules', function () {
-    it('it should work if path is different', function (done) {
-      let campsi = new CampsiServer(config.campsi);
+  describe('mount two modules', function() {
+    it('it should work if path is different', function(done) {
+      const campsi = new CampsiServer(config.campsi);
       let passed = true;
       try {
         campsi.mount('test', new TestService(config.services.test));
@@ -78,8 +78,8 @@ describe('Services Test', function () {
       }
     });
 
-    it('it should not work if path are equals', function (done) {
-      let campsi = new CampsiServer(config.campsi);
+    it('it should not work if path are equals', function(done) {
+      const campsi = new CampsiServer(config.campsi);
       let passed = false;
       try {
         campsi.mount('test', new TestService(config.services.test));

--- a/test/config/test.js
+++ b/test/config/test.js
@@ -88,9 +88,7 @@ module.exports = {
       description: 'Versioned docs db structure',
       options: {
         usersFetcher: async (usersId, server) => {
-          const users = await server.services
-            .get('auth')
-            .fetchUsers(usersId.map(u => u.userId));
+          const users = await server.services.get('auth').fetchUsers(usersId.map(u => u.userId));
           return users.map(u => {
             return u._id
               ? {

--- a/test/docs/config/options/docs.js
+++ b/test/docs/config/options/docs.js
@@ -1,7 +1,8 @@
 module.exports = {
-  usersFetcher: (users, server) => new Promise((resolve, reject) => {
-    resolve(users.map(user => Object.assign({}, user, {displayName: `External user ${user.userId}`})));
-  }),
+  usersFetcher: (users, server) =>
+    new Promise((resolve, reject) => {
+      resolve(users.map(user => Object.assign({}, user, { displayName: `External user ${user.userId}` })));
+    }),
   roles: {
     admin: {
       label: 'Administrateur',
@@ -167,17 +168,17 @@ module.exports = {
     pizzas: {
       label: 'La carte des pizzas',
       class: 'collection',
-      schema: {'$ref': '../../../schemas/pizza.schema.json'}
+      schema: { $ref: '../../../schemas/pizza.schema.json' }
     },
     contact: {
       label: 'Formulaire de contact du site web',
       class: 'form',
-      schema: {'$ref': '../../../schemas/contact.schema.json'}
+      schema: { $ref: '../../../schemas/contact.schema.json' }
     },
     opening_hours: {
       label: 'Jours et horaires de contact',
       class: 'document',
-      schema: {'$ref': '../../../schemas/opening_hours.schema.json'}
+      schema: { $ref: '../../../schemas/opening_hours.schema.json' }
     },
     categories: {
       label: 'Categories',
@@ -185,9 +186,7 @@ module.exports = {
       webhooks: [
         {
           on: 'POST,PUT,DELETE',
-          states: [
-            'published'
-          ],
+          states: ['published'],
           uri: 'http://127.0.0.1:3001',
           method: 'POST',
           payload: true,
@@ -198,7 +197,7 @@ module.exports = {
           }
         }
       ],
-      schema: {'$ref': '../../../schemas/category.schema.json'}
+      schema: { $ref: '../../../schemas/category.schema.json' }
     },
     articles: {
       label: 'Articles',
@@ -208,25 +207,21 @@ module.exports = {
           path: 'rels.oneToOneRelationship',
           resource: 'categories',
           embed: false,
-          fields: [
-            'label'
-          ]
+          fields: ['label']
         },
         other_categories: {
           path: 'rels.oneToManyRelationship.*',
           resource: 'categories',
           embed: false,
-          fields: [
-            'label'
-          ]
+          fields: ['label']
         }
       },
-      schema: {'$ref': '../../../schemas/article.schema.json'}
+      schema: { $ref: '../../../schemas/article.schema.json' }
     },
     simple: {
       label: 'A Simple Document',
       class: 'test-class',
-      schema: {'$ref': '../../../schemas/document.schema.json'}
+      schema: { $ref: '../../../schemas/document.schema.json' }
     }
   }
 };

--- a/test/docs/crud.js
+++ b/test/docs/crud.js
@@ -26,13 +26,13 @@ const services = {
 // Helpers
 function createPizza(data, state) {
   return new Promise(function(resolve, reject) {
-    let resource = campsi.services.get('docs').options.resources['pizzas'];
+    const resource = campsi.services.get('docs').options.resources.pizzas;
     builder
       .create({
         user: null,
-        data: data,
-        resource: resource,
-        state: state
+        data,
+        resource,
+        state
       })
       .then(doc => {
         resource.collection.insertOne(doc, (err, result) => {
@@ -53,7 +53,7 @@ describe('CRUD', () => {
     const mongoUri = mongoUriBuilder(config.campsi.mongo);
     MongoClient.connect(mongoUri, (err, client) => {
       if (err) throw err;
-      let db = client.db(config.campsi.mongo.database);
+      const db = client.db(config.campsi.mongo.database);
       db.dropDatabase(() => {
         client.close();
         campsi = new CampsiServer(config.campsi);
@@ -117,7 +117,7 @@ describe('CRUD', () => {
    */
   describe('/POST docs/pizzas', () => {
     it('it should not create a document (no credentials for default state)', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       chai
         .request(campsi.app)
         .post('/docs/pizzas')
@@ -138,7 +138,7 @@ describe('CRUD', () => {
    */
   describe('/GET docs/pizzas/:id', () => {
     it('it should return a 404 error', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createPizza(data, 'working_draft')
         .then(id => {
           chai

--- a/test/docs/docs-build-patch-query.js
+++ b/test/docs/docs-build-patch-query.js
@@ -3,7 +3,7 @@ const Ajv = require('ajv');
 const assert = chai.assert;
 const { patch } = require('../../services/docs/lib/modules/queryBuilder');
 
-let ajvWriter = new Ajv();
+const ajvWriter = new Ajv();
 const options = {
   resource: {
     label: 'project',
@@ -74,11 +74,7 @@ const options = {
 describe('queryBuilder patch function', () => {
   it('should return an object ready to be used in an update mongodb function, with $set and $unset operators', async () => {
     const patchResult = await patch(options);
-    if (
-      Object.prototype.toString.call(
-        patchResult.$set['states.published.modifiedAt']
-      ) === '[object Date]'
-    ) {
+    if (Object.prototype.toString.call(patchResult.$set['states.published.modifiedAt']) === '[object Date]') {
       // date would be different anyway so we won't compare it
       delete patchResult.$set['states.published.modifiedAt'];
     }
@@ -93,11 +89,7 @@ describe('queryBuilder patch function', () => {
   it('should return an object ready to be used in an update mongodb function, with only $set operator', async () => {
     delete options.data['DPO.address'];
     const patchResult = await patch(options);
-    if (
-      Object.prototype.toString.call(
-        patchResult.$set['states.published.modifiedAt']
-      ) === '[object Date]'
-    ) {
+    if (Object.prototype.toString.call(patchResult.$set['states.published.modifiedAt']) === '[object Date]') {
       // date would be different anyway so we won't compare it
       delete patchResult.$set['states.published.modifiedAt'];
     }

--- a/test/docs/events.js
+++ b/test/docs/events.js
@@ -3,7 +3,7 @@ process.env.NODE_CONFIG_DIR = './test/docs/config';
 process.env.NODE_ENV = 'test';
 
 // Require the dev-dependencies
-const {MongoClient} = require('mongodb');
+const { MongoClient } = require('mongodb');
 const mongoUriBuilder = require('mongo-uri-builder');
 const debug = require('debug')('campsi:test');
 const chai = require('chai');
@@ -23,16 +23,16 @@ const services = {
   Docs: require('../../services/docs/lib')
 };
 
-const me = {_id: 'me'};
+const me = { _id: 'me' };
 
 // Our parent block
 describe('Events', () => {
-  beforeEach((done) => {
+  beforeEach(done => {
     // Empty the database
     const mongoUri = mongoUriBuilder(config.campsi.mongo);
     MongoClient.connect(mongoUri, (err, client) => {
       if (err) throw err;
-      let db = client.db(config.campsi.mongo.database);
+      const db = client.db(config.campsi.mongo.database);
       db.dropDatabase(() => {
         client.close();
         campsi = new CampsiServer(config.campsi);
@@ -47,14 +47,14 @@ describe('Events', () => {
           done();
         });
 
-        campsi.start().catch((err) => {
+        campsi.start().catch(err => {
           debug('Error: %s', err);
         });
       });
     });
   });
 
-  afterEach((done) => {
+  afterEach(done => {
     server.close();
     done();
   });
@@ -64,69 +64,80 @@ describe('Events', () => {
    */
   describe('events', () => {
     it('should dispatch events for POST / PUT / SET STATE / DELETE', done => {
-      async.parallel([
-        cb => {
-          campsi.on('docs/document/created', payload => {
-            debug('docs/document/created');
-            payload.should.have.property('documentId');
-            payload.should.have.property('state');
-            payload.data.name.should.eq('test');
-            cb();
-          });
-        },
-        cb => {
-          campsi.on('docs/document/updated', payload => {
-            debug('docs/document/updated');
-            payload.should.have.property('documentId');
-            payload.should.have.property('state');
-            payload.data.name.should.eq('test modified');
-            cb();
-          });
-        },
-        cb => {
-          campsi.on('docs/document/state/changed', payload => {
-            debug('docs/document/state/changed', payload);
-            cb();
-          });
-        },
-        cb => {
-          campsi.on('docs/document/deleted', payload => {
-            debug('docs/document/deleted', payload);
-            payload.should.have.property('documentId');
-            cb();
-          });
-        }
-      ], done);
+      async.parallel(
+        [
+          cb => {
+            campsi.on('docs/document/created', payload => {
+              debug('docs/document/created');
+              payload.should.have.property('documentId');
+              payload.should.have.property('state');
+              payload.data.name.should.eq('test');
+              cb();
+            });
+          },
+          cb => {
+            campsi.on('docs/document/updated', payload => {
+              debug('docs/document/updated');
+              payload.should.have.property('documentId');
+              payload.should.have.property('state');
+              payload.data.name.should.eq('test modified');
+              cb();
+            });
+          },
+          cb => {
+            campsi.on('docs/document/state/changed', payload => {
+              debug('docs/document/state/changed', payload);
+              cb();
+            });
+          },
+          cb => {
+            campsi.on('docs/document/deleted', payload => {
+              debug('docs/document/deleted', payload);
+              payload.should.have.property('documentId');
+              cb();
+            });
+          }
+        ],
+        done
+      );
 
       let documentId;
       async.series([
-        cb => { // POST
-          chai.request(campsi.app)
+        cb => {
+          // POST
+          chai
+            .request(campsi.app)
             .post('/docs/simple/state-public')
             .set('content-type', 'application/json')
-            .send({name: 'test'})
+            .send({ name: 'test' })
             .end((err, res) => {
               if (err) debug(`received an error from chai: ${err.message}`);
               documentId = res.body.id;
               cb();
             });
         },
-        cb => { // PUT
-          chai.request(campsi.app)
+        cb => {
+          // PUT
+          chai
+            .request(campsi.app)
             .put(`/docs/simple/${documentId}`)
             .set('content-type', 'application/json')
-            .send({name: 'test modified'})
+            .send({ name: 'test modified' })
             .end(cb);
         },
-        cb => { // CHANGE STATE
-          chai.request(campsi.app)
+        cb => {
+          // CHANGE STATE
+          chai
+            .request(campsi.app)
             .put(`/docs/simple/${documentId}/state`)
             .set('content-type', 'application/json')
-            .send({from: 'state-public', to: 'state-basic'})
+            .send({ from: 'state-public', to: 'state-basic' })
             .end(cb);
         },
-        cb => { // DELETE
-          chai.request(campsi.app)
+        cb => {
+          // DELETE
+          chai
+            .request(campsi.app)
             .delete(`/docs/simple/${documentId}`)
             .set('content-type', 'application/json')
             .end(cb);
@@ -135,26 +146,31 @@ describe('Events', () => {
     });
     it('should dispatch events for document users POST / PUT / DELETE', done => {
       // event listeners
-      async.parallel([
-        cb => {
-          campsi.on('docs/document/users/added', payload => {
-            debug(payload);
-            cb();
-          });
-        },
-        cb => {
-          campsi.on('docs/document/users/removed', payload => {
-            debug(payload);
-            cb();
-          });
-        }
-      ], done);
+      async.parallel(
+        [
+          cb => {
+            campsi.on('docs/document/users/added', payload => {
+              debug(payload);
+              cb();
+            });
+          },
+          cb => {
+            campsi.on('docs/document/users/removed', payload => {
+              debug(payload);
+              cb();
+            });
+          }
+        ],
+        done
+      );
       let documentId;
       // requests
       async.series([
         cb => {
-          chai.request(campsi.app).post('/docs/simple')
-            .send({name: 'test'})
+          chai
+            .request(campsi.app)
+            .post('/docs/simple')
+            .send({ name: 'test' })
             .end((err, res) => {
               if (err) debug(`received an error from chai: ${err.message}`);
               documentId = res.body.id;
@@ -162,13 +178,18 @@ describe('Events', () => {
             });
         },
         cb => {
-          chai.request(campsi.app).post(`/docs/simple/${documentId}/users`)
+          chai
+            .request(campsi.app)
+            .post(`/docs/simple/${documentId}/users`)
             .set('content-type', 'application/json')
-            .send({_id: 'not_me', roles: ['owner']})
+            .send({ _id: 'not_me', roles: ['owner'] })
             .end(cb);
         },
         cb => {
-          chai.request(campsi.app).delete(`/docs/simple/${documentId}/users/not_me`).end(cb);
+          chai
+            .request(campsi.app)
+            .delete(`/docs/simple/${documentId}/users/not_me`)
+            .end(cb);
         }
       ]);
     });

--- a/test/docs/filters.js
+++ b/test/docs/filters.js
@@ -14,7 +14,6 @@ const config = require('config');
 const builder = require('../../services/docs/lib/modules/queryBuilder');
 const async = require('async');
 const fakeId = require('fake-object-id');
-const { response } = require('express');
 
 chai.should();
 let campsi;

--- a/test/docs/migrate_owner_to_users.js
+++ b/test/docs/migrate_owner_to_users.js
@@ -27,13 +27,13 @@ const services = {
 // Helpers
 function createPizza(data, state, ownerId) {
   return new Promise(function(resolve, reject) {
-    let resource = campsi.services.get('docs').options.resources['pizzas'];
+    const resource = campsi.services.get('docs').options.resources.pizzas;
     builder
       .create({
         user: null,
-        data: data,
-        resource: resource,
-        state: state
+        data,
+        resource,
+        state
       })
       .then(doc => {
         doc.ownedBy = ownerId;
@@ -51,7 +51,7 @@ function createPizza(data, state, ownerId) {
 
 function getPizzaById(id) {
   return new Promise(function(resolve, reject) {
-    let resource = campsi.services.get('docs').options.resources['pizzas'];
+    const resource = campsi.services.get('docs').options.resources.pizzas;
     resource.collection.findOne({ _id: id }, (err, pizza) => {
       return err ? reject(err) : resolve(pizza);
     });
@@ -65,7 +65,7 @@ describe('CRUD', () => {
     const mongoUri = mongoUriBuilder(config.campsi.mongo);
     MongoClient.connect(mongoUri, (err, client) => {
       if (err) throw err;
-      let db = client.db(config.campsi.mongo.database);
+      const db = client.db(config.campsi.mongo.database);
       db.dropDatabase(() => {
         client.close();
         campsi = new CampsiServer(config.campsi);

--- a/test/docs/owner.js
+++ b/test/docs/owner.js
@@ -15,7 +15,7 @@ const builder = require('../../services/docs/lib/modules/queryBuilder');
 const fakeId = require('fake-object-id');
 
 chai.should();
-let expect = chai.expect;
+const expect = chai.expect;
 let campsi;
 let server;
 format.extend(String.prototype);
@@ -25,23 +25,23 @@ const services = {
   Docs: require('../../services/docs/lib')
 };
 
-let me = {
+const me = {
   _id: fakeId()
 };
-let notMe = {
+const notMe = {
   _id: fakeId()
 };
 
 // Helpers
 function createEntry(data, owner, state) {
   return new Promise(function(resolve, reject) {
-    let resource = campsi.services.get('docs').options.resources['simple'];
+    const resource = campsi.services.get('docs').options.resources.simple;
     builder
       .create({
         user: owner,
-        data: data,
-        resource: resource,
-        state: state
+        data,
+        resource,
+        state
       })
       .then(doc => {
         resource.collection.insertOne(doc, (err, result) => {
@@ -62,7 +62,7 @@ describe('Owner', () => {
     const mongoUri = mongoUriBuilder(config.campsi.mongo);
     MongoClient.connect(mongoUri, (err, client) => {
       if (err) throw err;
-      let db = client.db(config.campsi.mongo.database);
+      const db = client.db(config.campsi.mongo.database);
       db.dropDatabase(() => {
         client.close();
         campsi = new CampsiServer(config.campsi);
@@ -94,7 +94,7 @@ describe('Owner', () => {
    */
   describe('owner role', () => {
     it('it should create a doc with correct owner', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       chai
         .request(campsi.app)
         .post('/docs/simple/state-private')
@@ -118,7 +118,7 @@ describe('Owner', () => {
         });
     });
     it('it should not get a document not owned by current user', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createEntry(data, notMe, 'state-private').then(id => {
         chai
           .request(campsi.app)
@@ -135,7 +135,7 @@ describe('Owner', () => {
       });
     });
     it('it should get a document owned by current user', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createEntry(data, me, 'state-private').then(id => {
         chai
           .request(campsi.app)
@@ -159,7 +159,7 @@ describe('Owner', () => {
       });
     });
     it('it should return an empty array if not on the good state', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createEntry(data, notMe, 'state-private').then(() => {
         chai
           .request(campsi.app)
@@ -174,7 +174,7 @@ describe('Owner', () => {
       });
     });
     it('it should return an empty array if current user have not created any document', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createEntry(data, notMe, 'state-private').then(() => {
         chai
           .request(campsi.app)
@@ -189,7 +189,7 @@ describe('Owner', () => {
       });
     });
     it('it should not return an empty array if current user have created a document', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createEntry(data, me, 'state-private').then(() => {
         chai
           .request(campsi.app)
@@ -204,7 +204,7 @@ describe('Owner', () => {
       });
     });
     it('it should return the list of users', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createEntry(data, me, 'state-private').then(id => {
         chai
           .request(campsi.app)
@@ -220,7 +220,7 @@ describe('Owner', () => {
       });
     });
     it('it should add and remove users', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createEntry(data, me, 'state-private').then(id => {
         chai
           .request(campsi.app)

--- a/test/docs/state.js
+++ b/test/docs/state.js
@@ -14,7 +14,7 @@ const CampsiServer = require('campsi');
 const config = require('config');
 const builder = require('../../services/docs/lib/modules/queryBuilder');
 
-let should = chai.should();
+const should = chai.should();
 let campsi;
 let server;
 format.extend(String.prototype);
@@ -27,13 +27,13 @@ const services = {
 // Helpers
 function createPizza(data, state) {
   return new Promise(function(resolve, reject) {
-    let resource = campsi.services.get('docs').options.resources['pizzas'];
+    const resource = campsi.services.get('docs').options.resources.pizzas;
     builder
       .create({
         user: null,
-        data: data,
-        resource: resource,
-        state: state
+        data,
+        resource,
+        state
       })
       .then(doc => {
         resource.collection.insertOne(doc, (err, result) => {
@@ -53,7 +53,7 @@ describe('State', () => {
     const mongoUri = mongoUriBuilder(config.campsi.mongo);
     MongoClient.connect(mongoUri, (err, client) => {
       if (err) throw err;
-      let db = client.db(config.campsi.mongo.database);
+      const db = client.db(config.campsi.mongo.database);
       db.dropDatabase(() => {
         client.close();
         campsi = new CampsiServer(config.campsi);
@@ -81,7 +81,7 @@ describe('State', () => {
    */
   describe('/POST docs/pizzas/:state', () => {
     it('it should create a document', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       chai
         .request(campsi.app)
         .post('/docs/pizzas/working_draft')
@@ -107,7 +107,7 @@ describe('State', () => {
    */
   describe('/GET docs/pizzas/:id/:state', () => {
     it('it should retreive a document by id/state', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createPizza(data, 'working_draft')
         .then(id => {
           chai
@@ -132,7 +132,7 @@ describe('State', () => {
         });
     });
     it('it should retreive a document by id/state with states', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createPizza(data, 'working_draft')
         .then(id => {
           chai
@@ -166,7 +166,7 @@ describe('State', () => {
         });
     });
     it('it should retreive a document by id/state with states empty', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createPizza(data, 'working_draft')
         .then(id => {
           chai
@@ -199,8 +199,8 @@ describe('State', () => {
    */
   describe('/PUT docs/pizzas/:id/:state', () => {
     it('it should modify a document by id/state', done => {
-      let data = { name: 'test' };
-      let modifiedData = {
+      const data = { name: 'test' };
+      const modifiedData = {
         name: 'test put',
         base: 'cream'
       };
@@ -215,8 +215,9 @@ describe('State', () => {
                   .set('content-type', 'application/json')
                   .send(modifiedData)
                   .end((err, res) => {
-                    if (err)
+                    if (err) {
                       debug(`received an error from chai: ${err.message}`);
+                    }
                     res.should.have.status(200);
                     res.should.be.json;
                     res.body.should.be.a('object');
@@ -234,8 +235,9 @@ describe('State', () => {
                   .request(campsi.app)
                   .get('/docs/pizzas/{0}/working_draft'.format(id))
                   .end((err, res) => {
-                    if (err)
+                    if (err) {
                       debug(`received an error from chai: ${err.message}`);
+                    }
                     res.should.have.status(200);
                     res.should.be.json;
                     res.body.should.be.a('object');
@@ -268,8 +270,8 @@ describe('State', () => {
    */
   describe('/PUT docs/pizzas/:id/state', () => {
     it('it should not modify a document state by id', done => {
-      let data = { name: 'test' };
-      let stateData = {
+      const data = { name: 'test' };
+      const stateData = {
         from: 'working_draft',
         to: 'published'
       };
@@ -300,7 +302,7 @@ describe('State', () => {
    */
   describe('/DELETE docs/pizzas/:id/state', () => {
     it('it should delete a document by id', done => {
-      let data = { name: 'test' };
+      const data = { name: 'test' };
       createPizza(data, 'working_draft')
         .then(id => {
           chai

--- a/test/docs/utils/initialization.js
+++ b/test/docs/utils/initialization.js
@@ -1,4 +1,4 @@
-const {MongoClient} = require('mongodb');
+const { MongoClient } = require('mongodb');
 const mongoUriBuilder = require('mongo-uri-builder');
 const CampsiServer = require('campsi');
 const debug = require('debug')('campsi-test');
@@ -9,8 +9,8 @@ format.extend(String.prototype);
 chai.use(chaiHttp);
 chai.should();
 
-module.exports = function initialize (config, services) {
-  let campsi = new CampsiServer(config.campsi);
+module.exports = function initialize(config, services) {
+  const campsi = new CampsiServer(config.campsi);
   Object.keys(services).forEach(service => {
     campsi.mount(service, new services[service](config.services[service]));
   });
@@ -20,21 +20,21 @@ module.exports = function initialize (config, services) {
   campsi.start();
   return {
     campsi,
-    beforeEachCallback: (done) => {
+    beforeEachCallback: done => {
       // Empty the database
       const mongoUri = mongoUriBuilder(config.campsi.mongo);
       MongoClient.connect(mongoUri, (err, client) => {
         if (err) {
           debug('Error during the mongo connection', err);
         }
-        let db = client.db(config.campsi.mongo.database);
+        const db = client.db(config.campsi.mongo.database);
         db.dropDatabase(() => {
           client.close();
           done();
         });
       });
     },
-    afterCallback: (done) => {
+    afterCallback: done => {
       campsi.server.close();
       done();
     }

--- a/test/helpers/createUser.js
+++ b/test/helpers/createUser.js
@@ -1,8 +1,9 @@
 const debug = require('debug')('campsi:test');
 
-module.exports = function createUser (chai, campsi, user) {
+module.exports = function createUser(chai, campsi, user) {
   return new Promise(resolve => {
-    chai.request(campsi.app)
+    chai
+      .request(campsi.app)
       .post('/auth/local/signup')
       .set('content-type', 'application/json')
       .send(user)

--- a/test/helpers/setupBeforeEach.js
+++ b/test/helpers/setupBeforeEach.js
@@ -7,15 +7,13 @@ module.exports = (config, services, context) => done => {
   const mongoUri = mongoUriBuilder(config.campsi.mongo);
   MongoClient.connect(mongoUri, (err, client) => {
     if (err) throw err;
-    let db = client.db(config.campsi.mongo.database);
+    const db = client.db(config.campsi.mongo.database);
     db.dropDatabase(() => {
       client.close();
       context.campsi = new CampsiServer(config.campsi);
       Object.entries(services).map(([name, service]) => {
-        context.campsi.mount(
-          name.toLowerCase(),
-          new service(config.services[name.toLowerCase()])
-        );
+        // eslint-disable-next-line new-cap
+        return context.campsi.mount(name.toLowerCase(), new service(config.services[name.toLowerCase()]));
       });
 
       context.campsi.on('campsi/ready', () => {

--- a/test/launchers/launch-campsi-auth-webhooks-assets.js
+++ b/test/launchers/launch-campsi-auth-webhooks-assets.js
@@ -14,7 +14,7 @@ const services = {
 };
 
 class Test extends CampsiService {
-  initialize () {
+  initialize() {
     this.router.get('/', (req, res) => {
       return res.json('OK !');
     });
@@ -22,7 +22,7 @@ class Test extends CampsiService {
   }
 }
 
-let campsi = new CampsiServer(config.campsi);
+const campsi = new CampsiServer(config.campsi);
 
 campsi.mount('test', new Test(config.services.test));
 campsi.mount('assets', new services.Assets(config.services.assets));
@@ -39,15 +39,14 @@ campsi.on('auth/local/passwordResetTokenCreated', user => {
 
 process.on('uncaughtException', (reason, p) => {
   debug('Uncaught Rejection at:', p, 'reason:', reason);
-  process.exit(1);
+  throw new Error(`Uncaught Rejection at: ${p}, reason: ${reason}`);
 });
 
 process.on('unhandledRejection', (reason, p) => {
   debug('Unhandled Rejection at:', p, 'reason:', reason);
-  process.exit(1);
+  throw new Error(`Uncaught Rejection at: ${p}, reason: ${reason}`);
 });
 
-campsi.start()
-  .catch((error) => {
-    debug(error);
-  });
+campsi.start().catch(error => {
+  debug(error);
+});

--- a/test/launchers/launch-docs.js
+++ b/test/launchers/launch-docs.js
@@ -9,12 +9,12 @@ const services = {
   Docs: require('../../services/docs/lib')
 };
 
-let campsi = new CampsiServer(config.campsi);
+const campsi = new CampsiServer(config.campsi);
 
 campsi.mount('docs', new services.Docs(config.services.docs));
 campsi.app.use((req, res, next) => {
   if (req.query && req.query.userId) {
-    req.user = {_id: req.query.userId};
+    req.user = { _id: req.query.userId };
   }
   next();
 });
@@ -24,7 +24,6 @@ campsi.on('campsi/ready', () => {
   campsi.listen(process.env.PORT || config.port);
 });
 
-campsi.start()
-  .catch((error) => {
-    debug(error);
-  });
+campsi.start().catch(error => {
+  debug(error);
+});

--- a/test/launchers/launch-trace.js
+++ b/test/launchers/launch-trace.js
@@ -1,4 +1,4 @@
-process.env.NODE_CONFIG_DIR = '../trace/config';
+process.env.NODE_CONFIG_DIR = '../config';
 process.env.NODE_ENV = 'test';
 
 const CampsiServer = require('campsi');
@@ -9,7 +9,7 @@ const services = {
   Trace: require('../../services/trace/lib')
 };
 
-let campsi = new CampsiServer(config.campsi);
+const campsi = new CampsiServer(config.campsi);
 
 campsi.mount('trace', new services.Trace(config.services.trace));
 
@@ -18,16 +18,15 @@ campsi.on('campsi/ready', () => {
   campsi.listen(config.port);
 });
 
-process.on('uncaughtException', function () {
+process.on('uncaughtException', function() {
   debug('uncaughtException');
 });
 
 process.on('unhandledRejection', (reason, p) => {
   debug('Unhandled Rejection at:', p, 'reason:', reason);
-  process.exit(1);
+  throw new Error(`Uncaught Rejection at: ${p}, reason: ${reason}`);
 });
 
-campsi.start()
-  .catch((error) => {
-    debug(error);
-  });
+campsi.start().catch(error => {
+  debug(error);
+});

--- a/test/stripe-billing/config/test.js
+++ b/test/stripe-billing/config/test.js
@@ -17,7 +17,7 @@ module.exports = {
       options: {
         secret_key: 'sk_test_TLvEhxPpHyrPhJeyMnJyM9jj',
         default_tax_percent: 20
-      },
+      }
     }
   }
 };

--- a/test/trace/trace.js
+++ b/test/trace/trace.js
@@ -23,29 +23,30 @@ const services = {
 
 // Our parent block
 describe('Trace', () => {
-  beforeEach((done) => { // Before each test we empty the database
+  beforeEach(done => {
+    // Before each test we empty the database
     campsi = new CampsiServer(config.campsi);
     campsi.mount('trace', new services.Trace(config.services.trace));
     campsi.on('campsi/ready', () => {
       server = campsi.listen(config.port);
       done();
     });
-    campsi.start()
-      .catch((err) => {
-        debug('Error: %s', err);
-      });
+    campsi.start().catch(err => {
+      debug('Error: %s', err);
+    });
   });
 
-  afterEach((done) => {
+  afterEach(done => {
     server.close();
     done();
   });
   /*
-     * Test the /GET trace route
-     */
+   * Test the /GET trace route
+   */
   describe('/GET trace', () => {
-    it('it should return success', (done) => {
-      chai.request(campsi.app)
+    it('it should return success', done => {
+      chai
+        .request(campsi.app)
         .get('/trace')
         .end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);
@@ -57,14 +58,15 @@ describe('Trace', () => {
     });
   });
   /*
-     * Test the /GET trace route
-     */
+   * Test the /GET trace route
+   */
   describe('/POST docs', () => {
-    it('it should return success', (done) => {
-      chai.request(campsi.app)
+    it('it should return success', done => {
+      chai
+        .request(campsi.app)
         .post('/trace/foo/bar')
         .set('content-type', 'application/json')
-        .send({testing: true, sender: 'mocha', deep: {description: 'more deeper object.'}})
+        .send({ testing: true, sender: 'mocha', deep: { description: 'more deeper object.' } })
         .end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);
           res.should.have.status(200);
@@ -75,11 +77,12 @@ describe('Trace', () => {
     });
   });
   /*
-     * Test the /GET trace route
-     */
+   * Test the /GET trace route
+   */
   describe('/POST docs', () => {
-    it('it should return success', (done) => {
-      chai.request(campsi.app)
+    it('it should return success', done => {
+      chai
+        .request(campsi.app)
         .post('/trace/file')
         .attach('file', fs.readFileSync('./test/rsrc/test.txt'), 'test.txt')
         .end((err, res) => {

--- a/test/versioned-docs/versioned-docs.js
+++ b/test/versioned-docs/versioned-docs.js
@@ -1,9 +1,9 @@
+/* eslint-disable no-unused-expressions */
 process.env.NODE_CONFIG_DIR = './test/config';
 process.env.NODE_ENV = 'test';
 
 const chai = require('chai');
 const chaiHttp = require('chai-http');
-const debug = require('debug')('campsi:test');
 const config = require('config');
 const setupBeforeEach = require('../helpers/setupBeforeEach');
 const createObjectId = require('../../lib/modules/createObjectId');
@@ -29,7 +29,7 @@ let revision = {
 let version = {};
 
 describe('VersionedDocs API', () => {
-  let context = {};
+  const context = {};
   before(setupBeforeEach(config, services, context));
   after(() => context.server.close());
 
@@ -60,16 +60,12 @@ describe('VersionedDocs API', () => {
       res.should.be.json;
       res.body.should.be.a('object');
       res.body.should.have.property('message');
-      res.body.message.should.be
-        .a('string')
-        .and.eq(" should have required property 'content'");
+      res.body.message.should.be.a('string').and.eq(" should have required property 'content'");
     });
   });
   describe('/GET all documents', () => {
     it('it should return an array of documents', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get('/versioneddocs/contracts/');
+      const res = await chai.request(context.campsi.app).get('/versioneddocs/contracts/');
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('array');
@@ -79,9 +75,7 @@ describe('VersionedDocs API', () => {
   });
   describe('/GET a specific document', () => {
     it('it should return a document', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get(`/versioneddocs/contracts/${current._id}`);
+      const res = await chai.request(context.campsi.app).get(`/versioneddocs/contracts/${current._id}`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -126,17 +120,13 @@ describe('VersionedDocs API', () => {
       res.should.be.json;
       res.body.should.be.an('object');
       res.body.should.have.property('message');
-      res.body.message.should.be.eq(
-        'Precondition Failed: ETag revision mismatch'
-      );
+      res.body.message.should.be.eq('Precondition Failed: ETag revision mismatch');
     });
   });
 
   describe('/GET all document revisions', () => {
     it('it should return an array of document revisions', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get(`/versioneddocs/contracts/${current._id}/revisions/`);
+      const res = await chai.request(context.campsi.app).get(`/versioneddocs/contracts/${current._id}/revisions/`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('array');
@@ -148,11 +138,7 @@ describe('VersionedDocs API', () => {
 
   describe('/GET a specific document revision', () => {
     it('it should return a document revision (by id)', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get(
-          `/versioneddocs/contracts/${current._id}/revisions/${revision._id}`
-        );
+      const res = await chai.request(context.campsi.app).get(`/versioneddocs/contracts/${current._id}/revisions/${revision._id}`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -160,9 +146,7 @@ describe('VersionedDocs API', () => {
       res.body.currentId.should.be.equal(current._id.toString());
     });
     it('it should return a document revision (by revision number)', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get(`/versioneddocs/contracts/${current._id}/revisions/1`);
+      const res = await chai.request(context.campsi.app).get(`/versioneddocs/contracts/${current._id}/revisions/1`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -170,9 +154,7 @@ describe('VersionedDocs API', () => {
       res.body.currentId.should.be.equal(current._id.toString());
     });
     it('it should return an error for wrong revision query param', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get(`/versioneddocs/contracts/${current._id}/revisions/whatever`);
+      const res = await chai.request(context.campsi.app).get(`/versioneddocs/contracts/${current._id}/revisions/whatever`);
       res.should.have.status(500);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -185,9 +167,7 @@ describe('VersionedDocs API', () => {
     it('it should create a version', async () => {
       const res = await chai
         .request(context.campsi.app)
-        .post(
-          `/versioneddocs/contracts/${current._id}/revisions/${revision.revision}:set-as-version`
-        );
+        .post(`/versioneddocs/contracts/${current._id}/revisions/${revision.revision}:set-as-version`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -199,9 +179,7 @@ describe('VersionedDocs API', () => {
     it('it should create a version based on current.revision', async () => {
       const res = await chai
         .request(context.campsi.app)
-        .post(
-          `/versioneddocs/contracts/${current._id}/revisions/${current.revision}:set-as-version`
-        );
+        .post(`/versioneddocs/contracts/${current._id}/revisions/${current.revision}:set-as-version`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -213,9 +191,7 @@ describe('VersionedDocs API', () => {
 
   describe('/GET all document versions', () => {
     it('it should return an array of document versions', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get(`/versioneddocs/contracts/${current._id}/versions/`);
+      const res = await chai.request(context.campsi.app).get(`/versioneddocs/contracts/${current._id}/versions/`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('array');
@@ -227,9 +203,7 @@ describe('VersionedDocs API', () => {
 
   describe('/GET a specific version', () => {
     it('it should return a document version (by id)', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get(`/versioneddocs/contracts/${current._id}/versions/${version._id}`);
+      const res = await chai.request(context.campsi.app).get(`/versioneddocs/contracts/${current._id}/versions/${version._id}`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -237,9 +211,7 @@ describe('VersionedDocs API', () => {
       res.body.currentId.should.be.equal(current._id.toString());
     });
     it('it should return a document version (by version number)', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get(`/versioneddocs/contracts/${current._id}/versions/1`);
+      const res = await chai.request(context.campsi.app).get(`/versioneddocs/contracts/${current._id}/versions/1`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -247,9 +219,7 @@ describe('VersionedDocs API', () => {
       res.body.currentId.should.be.equal(current._id.toString());
     });
     it('it should return a document version (by version number created through current revision)', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get(`/versioneddocs/contracts/${current._id}/versions/2`);
+      const res = await chai.request(context.campsi.app).get(`/versioneddocs/contracts/${current._id}/versions/2`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -259,9 +229,7 @@ describe('VersionedDocs API', () => {
     it('it should return a document version (by tag)', async () => {
       const res = await chai
         .request(context.campsi.app)
-        .get(
-          `/versioneddocs/contracts/${current._id}/versions/?tag=${version.tag}`
-        );
+        .get(`/versioneddocs/contracts/${current._id}/versions/?tag=${version.tag}`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -269,9 +237,7 @@ describe('VersionedDocs API', () => {
       res.body.currentId.should.be.equal(current._id.toString());
     });
     it('it should return an error for wrong version query param', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .get(`/versioneddocs/contracts/${current._id}/versions/whatever`);
+      const res = await chai.request(context.campsi.app).get(`/versioneddocs/contracts/${current._id}/versions/whatever`);
       res.should.have.status(500);
       res.should.be.json;
       res.body.should.be.an('object');
@@ -282,9 +248,7 @@ describe('VersionedDocs API', () => {
 
   describe('/DELETE a document and all its versions/revisions', () => {
     it('it should return an array of mongoDB DeleteResult', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .delete(`/versioneddocs/contracts/${current._id}`);
+      const res = await chai.request(context.campsi.app).delete(`/versioneddocs/contracts/${current._id}`);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.an('array');

--- a/test/webhooks/setupBeforeEach.js
+++ b/test/webhooks/setupBeforeEach.js
@@ -1,13 +1,13 @@
 const CampsiServer = require('campsi');
-const {MongoClient} = require('mongodb');
+const { MongoClient } = require('mongodb');
 const mongoUriBuilder = require('mongo-uri-builder');
 const debug = require('debug')('campsi:test');
 
-module.exports = (config, services, context) => (done) => {
+module.exports = (config, services, context) => done => {
   const mongoUri = mongoUriBuilder(config.campsi.mongo);
   MongoClient.connect(mongoUri, (err, client) => {
     if (err) throw err;
-    let db = client.db(config.campsi.mongo.database);
+    const db = client.db(config.campsi.mongo.database);
     db.dropDatabase(() => {
       client.close();
       context.campsi = new CampsiServer(config.campsi);
@@ -17,10 +17,9 @@ module.exports = (config, services, context) => (done) => {
         context.server = context.campsi.listen(config.port);
         done();
       });
-      context.campsi.start()
-        .catch((err) => {
-          debug('Error: %s', err);
-        });
+      context.campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 };

--- a/test/webhooks/webhooks.js
+++ b/test/webhooks/webhooks.js
@@ -1,15 +1,11 @@
 process.env.NODE_CONFIG_DIR = './test/config';
 process.env.NODE_ENV = 'test';
 
-const { MongoClient } = require('mongodb');
-const mongoUriBuilder = require('mongo-uri-builder');
 const debug = require('debug')('campsi:test');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
-const CampsiServer = require('campsi');
 const config = require('config');
 const setupBeforeEach = require('../helpers/setupBeforeEach');
-let campsi;
 
 chai.use(chaiHttp);
 chai.should();
@@ -19,13 +15,14 @@ const services = {
 };
 
 describe('Webhooks', () => {
-  let context = {};
+  const context = {};
   beforeEach(setupBeforeEach(config, services, context));
   afterEach(done => context.server.close(done));
 
   describe('Basic webhook', () => {
     it('it should list webhooks', done => {
-      chai.request(context.campsi.app)
+      chai
+        .request(context.campsi.app)
         .get('/webhooks')
         .end((err, res) => {
           debug(err, res);
@@ -35,13 +32,14 @@ describe('Webhooks', () => {
     it('it should create a webhook', done => {
       const campsi = context.campsi;
 
-      campsi.on('trace/request', (payload) => {
+      campsi.on('trace/request', payload => {
         payload.should.be.a('object');
         payload.method.should.be.eq('GET');
         done();
       });
 
-      chai.request(context.campsi.app)
+      chai
+        .request(context.campsi.app)
         .post('/webhooks')
         .set('content-type', 'application/json')
         .send({
@@ -50,7 +48,7 @@ describe('Webhooks', () => {
           method: 'post'
         })
         .end((err, res) => {
-          debug('request ',err, res);
+          debug('request ', err, res);
           done();
         });
     });


### PR DESCRIPTION
The main purpose of this PR is apply the same lint and prettier configuration that is being used in CaaS-API to campsi-mono.

Lint and prettier have been run on all the source files and issues have been corrected. Please pay particular attention to the versioned-docs where the double negations have been substituted for a normal truthy test.

I have also used husky to run lint and the tests on the commit hook. If they fail the code will not commit.
