### PR TITLE
Jameslotery/axe 808 docs as a developper i want links to

### DIFF
--- a/lib/modules/buildLink.js
+++ b/lib/modules/buildLink.js
@@ -15,6 +15,18 @@ module.exports = function buildLink(req, page, keptParams) {
 };
 
 module.exports = function buildSingleDocumentLink(req, id) {
-  const path = req.baseUrl + req.path.substring(0, req.path.lastIndexOf('/') + 1) + id;
+  const pathFragments = req.path.split('/');
+  let path = req.baseUrl;
+
+  // path can be either /resource/id or /resource/id/state
+  if (pathFragments.length >= 2) {
+    path += '/' + pathFragments[1] + '/' + id;
+
+    // this should be the state if it's present
+    if (pathFragments.length === 4) {
+      path += '/' + pathFragments[3];
+    }
+  }
+
   return '{0}://{1}{2}'.format(req.protocol, req.get('host'), path);
 };

--- a/lib/modules/buildLink.js
+++ b/lib/modules/buildLink.js
@@ -13,3 +13,8 @@ module.exports = function buildLink(req, page, keptParams) {
     .join('&');
   return '{0}://{1}{2}?{3}'.format(req.protocol, req.get('host'), path, query);
 };
+
+module.exports = function buildSingleDocumentLink(req, id) {
+  const path = req.baseUrl + req.path.substring(0, req.path.lastIndexOf('/') + 1) + id;
+  return '{0}://{1}{2}'.format(req.protocol, req.get('host'), path);
+};

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -133,7 +133,7 @@ module.exports.patchDoc = async (req, res) => {
 // get a doc
 module.exports.getDoc = function(req, res) {
   documentService
-    .getDocument(req.resource, req.filter, req.query, req.user, req.state, req.options.resources)
+    .getDocument(req.resource, req.filter, req.query, req.user, req.state, req.options.resources, req.headers)
     .then(result => helpers.json(res, result))
     .catch(err => helpers.notFound(res, err));
 };

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -30,7 +30,7 @@ function dispatchError(res, error) {
   }
 }
 
-module.exports.getDocuments = function(req, res) {
+module.exports.getDocuments = function (req, res) {
   const pagination = {};
   const perPage = req.query.perPage || req.resource.perPage;
   if (perPage) pagination.perPage = perPage;
@@ -74,7 +74,7 @@ Object.defineProperty(module.exports.getDocuments, 'apidoc', {
   }
 });
 
-module.exports.postDoc = function(req, res) {
+module.exports.postDoc = function (req, res) {
   if (!!req.query?.parentId && !ObjectId.isValid(req.query.parentId)) {
     return helpers.badRequest(res, new Error('Invalid parent id'));
   }
@@ -91,7 +91,7 @@ module.exports.postDoc = function(req, res) {
 };
 
 // modify the state of a doc
-module.exports.putDocState = function(req, res) {
+module.exports.putDocState = function (req, res) {
   documentService
     .setDocumentState(req.resource, req.filter, req.body.from, req.body.to, req.user)
     .then(result => helpers.json(res, result))
@@ -102,7 +102,7 @@ module.exports.putDocState = function(req, res) {
 };
 
 // modify a doc
-module.exports.putDoc = function(req, res) {
+module.exports.putDoc = function (req, res) {
   documentService
     .setDocument(req.resource, req.filter, req.body, req.state, req.user)
     .then(result => helpers.json(res, result))
@@ -131,14 +131,26 @@ module.exports.patchDoc = async (req, res) => {
 };
 
 // get a doc
-module.exports.getDoc = function(req, res) {
+module.exports.getDoc = function (req, res) {
   documentService
     .getDocument(req.resource, req.filter, req.query, req.user, req.state, req.options.resources, req.headers)
+    .then(result =>
+      documentService.getDocumentLinks(
+        req.resource,
+        req.filter,
+        req.query,
+        req.user,
+        req.state,
+        req.options.resources,
+        req.headers,
+        result
+      )
+    )
     .then(result => helpers.json(res, result))
     .catch(err => helpers.notFound(res, err));
 };
 
-module.exports.delDoc = function(req, res) {
+module.exports.delDoc = function (req, res) {
   documentService
     .deleteDocument(req.resource, req.filter)
     .then(result => {
@@ -148,7 +160,7 @@ module.exports.delDoc = function(req, res) {
     .catch(err => helpers.notFound(res, err));
 };
 
-module.exports.getResources = function(req, res) {
+module.exports.getResources = function (req, res) {
   resourceService.getResources(req.options).then(result => {
     return helpers.json(res, result);
   });
@@ -160,7 +172,7 @@ Object.defineProperty(module.exports.getResources, 'apidoc', {
   }
 });
 
-module.exports.getDocUsers = function(req, res) {
+module.exports.getDocUsers = function (req, res) {
   documentService
     .getDocumentUsers(req.resource, req.filter)
     .then(users => userService.fetchUsers(users, req.options, req.service.server))
@@ -168,7 +180,7 @@ module.exports.getDocUsers = function(req, res) {
     .catch(err => helpers.notFound(res, err));
 };
 
-module.exports.postDocUser = function(req, res) {
+module.exports.postDocUser = function (req, res) {
   documentService
     .addUserToDocument(req.resource, req.filter, req.body)
     .then(users => userService.fetchUsers(users, req.options, req.service.server))
@@ -177,7 +189,7 @@ module.exports.postDocUser = function(req, res) {
     .catch(err => helpers.notFound(res, err));
 };
 
-module.exports.delDocUser = function(req, res) {
+module.exports.delDocUser = function (req, res) {
   documentService
     .removeUserFromDocument(req.resource, req.filter, req.params.user, req.db)
     .then(users => userService.fetchUsers(users, req.options, req.service.server))

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -147,12 +147,12 @@ module.exports.getDoc = function (req, res) {
         result
       )
     )
-    .then(result => {
-      if (result.nav && (result.nav.next || result.nav.previous)) {
+    .then(([nav, result]) => {
+      if (nav && (nav.next || nav.previous)) {
         const headers = {};
         const links = [];
 
-        Object.entries(result.nav).forEach(([rel, id]) => {
+        Object.entries(nav).forEach(([rel, id]) => {
           links.push(`<${buildSingleDocumentLink(req, id)}>; rel="${rel}"`);
         });
 

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -147,8 +147,7 @@ module.exports.getDoc = function (req, res) {
         result
       )
     )
-    .then(ret => {
-      const { result, nav } = ret;
+    .then(({ result, nav }) => {
       if (nav && (nav.next || nav.previous)) {
         const headers = {};
         const links = [];

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -147,7 +147,8 @@ module.exports.getDoc = function (req, res) {
         result
       )
     )
-    .then(([nav, result]) => {
+    .then(ret => {
+      const { result, nav } = ret;
       if (nav && (nav.next || nav.previous)) {
         const headers = {};
         const links = [];

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -245,6 +245,8 @@ module.exports.patchDocument = async (resource, filter, data, state, user) => {
 };
 
 module.exports.getDocumentLinks = function (resource, filter, query, _user, state, _resources, headers, result) {
+  const nav = {};
+
   return new Promise((resolve, _reject) => {
     if (
       (headers &&
@@ -252,7 +254,7 @@ module.exports.getDocumentLinks = function (resource, filter, query, _user, stat
         (!query.withLinks || query.withLinks === 'false')) ||
       resource.isInheritable
     ) {
-      return resolve(result);
+      return resolve([nav, result]);
     }
 
     const projection = { _id: 1, states: 1, users: 1, groups: 1 };
@@ -272,7 +274,7 @@ module.exports.getDocumentLinks = function (resource, filter, query, _user, stat
       .toArray()
       .then((doc, err) => {
         // if there is an error don't build the links
-        if (err) return resolve(result);
+        if (err) return resolve([nav, result]);
 
         if (doc && doc.length > 0) {
           previous = doc[0];
@@ -291,12 +293,10 @@ module.exports.getDocumentLinks = function (resource, filter, query, _user, stat
               next = doc[0];
             }
 
-            result.nav = {};
+            if (next && next._id) nav.next = next._id;
+            if (previous && previous._id) nav.previous = previous._id;
 
-            if (next && next._id) result.nav.next = next._id;
-            if (previous && previous._id) result.nav.previous = previous._id;
-
-            return resolve(result);
+            return resolve([nav, result]);
           })
           .catch(err => {
             console.log(err);

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -254,7 +254,7 @@ module.exports.getDocumentLinks = function (resource, filter, query, _user, stat
         (!query.withLinks || query.withLinks === 'false')) ||
       resource.isInheritable
     ) {
-      return resolve([nav, result]);
+      return resolve({ nav, result });
     }
 
     const projection = { _id: 1, states: 1, users: 1, groups: 1 };
@@ -274,7 +274,7 @@ module.exports.getDocumentLinks = function (resource, filter, query, _user, stat
       .toArray()
       .then((doc, err) => {
         // if there is an error don't build the links
-        if (err) return resolve([nav, result]);
+        if (err) return resolve({ nav, result });
 
         if (doc && doc.length > 0) {
           previous = doc[0];
@@ -296,7 +296,7 @@ module.exports.getDocumentLinks = function (resource, filter, query, _user, stat
             if (next && next._id) nav.next = next._id;
             if (previous && previous._id) nav.previous = previous._id;
 
-            return resolve([nav, result]);
+            return resolve({ nav, result });
           })
           .catch(err => {
             console.log(err);

--- a/test/docs/document-links.js
+++ b/test/docs/document-links.js
@@ -13,6 +13,7 @@ const CampsiServer = require('campsi');
 const config = require('config');
 const builder = require('../../services/docs/lib/modules/queryBuilder');
 const fakeId = require('fake-object-id');
+const { ObjectId } = require('mongodb');
 
 chai.should();
 let campsi;
@@ -34,8 +35,13 @@ const services = {
   Docs: require('../../services/docs/lib')
 };
 
+function deletePizza(pizzaId) {
+  const filter = { _id: new ObjectId(pizzaId) };
+  const resource = campsi.services.get('docs').options.resources.pizzas;
+  return resource.collection.deleteOne(filter);
+}
 function buildPizzaDoc(data, resource, state) {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     builder
       .create({
         user: owner,
@@ -57,7 +63,7 @@ function buildPizzaDoc(data, resource, state) {
 
 // Helpers
 function createPizzas() {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     const resource = campsi.services.get('docs').options.resources.pizzas;
     const pizzas = [];
     const promises = [];
@@ -133,7 +139,7 @@ function getPizzaWithoutLinksInHeader(id) {
       .set({ 'With-Links': false })
       .end((err, res) => {
         if (err) console.log(`received an error from chai: ${err.message}`);
-        resolve(res.body);
+        resolve(res);
       });
   });
 }
@@ -199,79 +205,83 @@ describe('Document links', () => {
    */
   describe('/GET pizzas starting from the first all the way to last following the links', () => {
     it('gets first pizza with correct links', done => {
-      getPizzaWithLinks(firstPizza).then(body => {
-        body.next_id.should.eq(secondPizza);
-        body.should.not.have.property('previous_id');
+      getPizzaWithLinksInHeader(firstPizza).then(body => {
+        body.nav.next.should.eq(secondPizza);
+        body.nav.should.not.have.property('previous');
         done();
       });
     });
     it('gets 2nd pizza with correct links', done => {
-      getPizzaWithLinksInHeader(secondPizza).then(body => {
-        body.previous_id.should.eq(firstPizza);
-        body.next_id.should.eq(thirdPizza);
+      getPizzaWithLinks(secondPizza).then(body => {
+        body.nav.previous.should.eq(firstPizza);
+        body.nav.next.should.eq(thirdPizza);
         done();
       });
     });
     it('gets third pizza with correct links', done => {
-      getPizzaWithLinks(thirdPizza).then(body => {
-        body.previous_id.should.eq(secondPizza);
-        body.next_id.should.eq(fourthPizza);
+      getPizzaWithLinksInHeader(thirdPizza).then(body => {
+        body.nav.previous.should.eq(secondPizza);
+        body.nav.next.should.eq(fourthPizza);
         done();
       });
     });
     it('gets fourth pizza with correct links', done => {
       getPizzaWithLinksInHeader(fourthPizza).then(body => {
-        body.previous_id.should.eq(thirdPizza);
-        body.next_id.should.eq(fifthPizza);
+        body.nav.previous.should.eq(thirdPizza);
+        body.nav.next.should.eq(fifthPizza);
         done();
       });
     });
     it('gets fifth pizza with correct links', done => {
       getPizzaWithLinks(fifthPizza).then(body => {
-        body.should.not.have.property('next_id');
-        body.previous_id.should.eq(fourthPizza);
+        body.nav.should.not.have.property('next');
+        body.nav.previous.should.eq(fourthPizza);
         done();
       });
     });
-  });
-
-  /*
-   * Test the /GET docs/pizzas route
-   */
-  describe('/GET each pizza one by one with links switched off or set to false, checks for no links', () => {
     it('it should get first pizza with no links returned', done => {
       getPizzaWithLinkOptionSetToFalse(firstPizza).then(body => {
-        body.should.not.have.property('next_id');
-        body.should.not.have.property('previous_id');
+        body.should.not.have.property('nav');
+        body.should.not.have.property('nav');
         done();
       });
     });
     it('it should get 2nd pizza with no links returned', done => {
       getPizzaWithoutLinks(secondPizza).then(body => {
-        body.should.not.have.property('next_id');
-        body.should.not.have.property('previous_id');
+        body.should.not.have.property('nav');
+        body.should.not.have.property('nav');
         done();
       });
     });
     it('it should get 3rd pizza with no links returned', done => {
-      getPizzaWithoutLinksInHeader(thirdPizza).then(body => {
-        body.should.not.have.property('next_id');
-        body.should.not.have.property('previous_id');
+      getPizzaWithoutLinksInHeader(thirdPizza).then(res => {
+        res.body.should.not.have.property('nav');
+        res.body.should.not.have.property('nav');
         done();
       });
     });
     it('it should get 4th pizza with no links returned', done => {
       getPizzaWithoutLinks(fourthPizza).then(body => {
-        body.should.not.have.property('next_id');
-        body.should.not.have.property('previous_id');
+        body.should.not.have.property('nav');
+        body.should.not.have.property('nav');
         done();
       });
     });
     it('it should get 5th pizza with no links returned', done => {
-      getPizzaWithoutLinksInHeader(fifthPizza).then(body => {
-        body.should.not.have.property('next_id');
-        body.should.not.have.property('previous_id');
+      getPizzaWithoutLinksInHeader(fifthPizza).then(res => {
+        res.body.should.not.have.property('nav');
+        res.body.should.not.have.property('nav');
         done();
+      });
+    });
+    it('should fail if I delete a document and ask for it', done => {
+      deletePizza(fourthPizza).then(() => {
+        getPizzaWithoutLinksInHeader(fourthPizza).then(res => {
+          res.body.should.not.have.property('nav');
+          res.body.should.not.have.property('nav');
+          res.status.should.eq(404);
+          done();
+        });
       });
     });
   });

--- a/test/docs/document-links.js
+++ b/test/docs/document-links.js
@@ -1,0 +1,206 @@
+/* eslint-disable no-unused-expressions */
+process.env.NODE_CONFIG_DIR = './test/docs/config';
+process.env.NODE_ENV = 'test';
+
+// Require the dev-dependencies
+const { MongoClient } = require('mongodb');
+const mongoUriBuilder = require('mongo-uri-builder');
+const debug = require('debug')('campsi:test');
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const format = require('string-format');
+const CampsiServer = require('campsi');
+const config = require('config');
+const builder = require('../../services/docs/lib/modules/queryBuilder');
+const fakeId = require('fake-object-id');
+
+chai.should();
+let campsi;
+let server;
+format.extend(String.prototype);
+chai.use(chaiHttp);
+
+let firstPizza;
+let secondPizza;
+let thirdPizza;
+let fourthPizza;
+let fifthPizza;
+
+const owner = {
+  _id: fakeId()
+};
+
+const services = {
+  Docs: require('../../services/docs/lib')
+};
+
+function buildPizzaDoc(data, resource, state) {
+  return new Promise(function(resolve, reject) {
+    builder
+      .create({
+        user: owner,
+        data,
+        resource,
+        state
+      })
+      .then(doc => {
+        resource.collection.insertOne(doc, (err, result) => {
+          if (err) return reject(err);
+          resolve(result.insertedId);
+        });
+      })
+      .catch(error => {
+        reject(error);
+      });
+  });
+}
+
+// Helpers
+function createPizzas() {
+  return new Promise(function(resolve, reject) {
+    const resource = campsi.services.get('docs').options.resources.pizzas;
+    const pizzas = [];
+    const promises = [];
+
+    for (let i = 0; i < 5; i++) {
+      pizzas.push({ data: { name: `margherita_${i}` }, resource, state: 'published' });
+    }
+
+    pizzas.forEach(item => {
+      promises.push(buildPizzaDoc(item.data, item.resource, item.state));
+    });
+
+    Promise.all(promises).then(() => {
+      resolve();
+    });
+  });
+}
+
+function getPizzaWithLinks(id) {
+  return new Promise(resolve => {
+    chai
+      .request(campsi.app)
+      .get(`/docs/pizzas/${id}?withLinks=true`)
+      .end((err, res) => {
+        if (err) debug(`received an error from chai: ${err.message}`);
+        resolve(res.body);
+      });
+  });
+}
+
+function getPizzaWithoutLinks(id) {
+  return new Promise(resolve => {
+    chai
+      .request(campsi.app)
+      .get(`/docs/pizzas/${id}`)
+      .end((err, res) => {
+        if (err) debug(`received an error from chai: ${err.message}`);
+        resolve(res.body);
+      });
+  });
+}
+
+// Our parent block
+describe('Document links', () => {
+  before(done => {
+    // Empty the database
+    const mongoUri = mongoUriBuilder(config.campsi.mongo);
+    MongoClient.connect(mongoUri, (err, client) => {
+      if (err) throw err;
+      const db = client.db(config.campsi.mongo.database);
+      db.dropDatabase(() => {
+        client.close();
+        campsi = new CampsiServer(config.campsi);
+        campsi.mount('docs', new services.Docs(config.services.docs));
+
+        campsi.on('campsi/ready', () => {
+          server = campsi.listen(config.port);
+
+          createPizzas().then(() => done());
+        });
+
+        campsi.start().catch(err => {
+          debug('Error: %s', err);
+        });
+      });
+    });
+  });
+
+  after(done => {
+    server.close();
+    done();
+  });
+
+  /*
+   * Test the /GET docs/pizzas route
+   */
+  describe('/GET docs/docs/pizzas', () => {
+    it('it should get all the pizzas', done => {
+      chai
+        .request(campsi.app)
+        .get('/docs/pizzas/')
+        .end((err, res) => {
+          if (err) debug(`received an error from chai: ${err.message}`);
+          res.should.have.status(200);
+          res.should.not.have.header('link');
+          res.should.be.json;
+          res.body.should.be.a('array');
+          firstPizza = res.body[0].id;
+          secondPizza = res.body[1].id;
+          thirdPizza = res.body[2].id;
+          fourthPizza = res.body[3].id;
+          fifthPizza = res.body[4].id;
+
+          done();
+        });
+    });
+  });
+
+  /*
+   * Test the /GET docs/pizzas route
+   */
+  describe('/GET first from the collection should have no previous link but should have next link', () => {
+    it('it should get a document with a link to the next one and the previous one', done => {
+      getPizzaWithLinks(firstPizza).then(body => {
+        body.next_id.should.eq(secondPizza);
+        body.should.not.have.property('previous_id');
+        getPizzaWithLinks(secondPizza).then(body => {
+          body.previous_id.should.eq(firstPizza);
+          body.next_id.should.eq(thirdPizza);
+          getPizzaWithLinks(thirdPizza).then(body => {
+            body.previous_id.should.eq(secondPizza);
+            body.next_id.should.eq(fourthPizza);
+            getPizzaWithLinks(fourthPizza).then(body => {
+              body.previous_id.should.eq(thirdPizza);
+              body.next_id.should.eq(fifthPizza);
+              getPizzaWithLinks(fifthPizza).then(body => {
+                body.should.not.have.property('next_id');
+                body.previous_id.should.eq(fourthPizza);
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  /*
+   * Test the /GET docs/pizzas route
+   */
+  describe('GET WITHOUT LINKS', () => {
+    it('it should get a document with no links', done => {
+      getPizzaWithoutLinks(firstPizza).then(body => {
+        getPizzaWithoutLinks(secondPizza).then(body => {
+          getPizzaWithoutLinks(thirdPizza).then(body => {
+            getPizzaWithoutLinks(fourthPizza).then(body => {
+              getPizzaWithoutLinks(fifthPizza).then(body => {
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/docs/document-links.js
+++ b/test/docs/document-links.js
@@ -88,6 +88,19 @@ function getPizzaWithLinks(id) {
   });
 }
 
+function getPizzaWithLinksInHeader(id) {
+  return new Promise(resolve => {
+    chai
+      .request(campsi.app)
+      .get(`/docs/pizzas/${id}`)
+      .set({ 'With-Links': true })
+      .end((err, res) => {
+        if (err) debug(`received an error from chai: ${err.message}`);
+        resolve(res.body);
+      });
+  });
+}
+
 function getPizzaWithoutLinks(id) {
   return new Promise(resolve => {
     chai
@@ -95,6 +108,31 @@ function getPizzaWithoutLinks(id) {
       .get(`/docs/pizzas/${id}`)
       .end((err, res) => {
         if (err) debug(`received an error from chai: ${err.message}`);
+        resolve(res.body);
+      });
+  });
+}
+
+function getPizzaWithLinkOptionSetToFalse(id) {
+  return new Promise(resolve => {
+    chai
+      .request(campsi.app)
+      .get(`/docs/pizzas/${id}?withLinks=false`)
+      .end((err, res) => {
+        if (err) debug(`received an error from chai: ${err.message}`);
+        resolve(res.body);
+      });
+  });
+}
+
+function getPizzaWithoutLinksInHeader(id) {
+  return new Promise(resolve => {
+    chai
+      .request(campsi.app)
+      .get(`/docs/pizzas/${id}`)
+      .set({ 'With-Links': false })
+      .end((err, res) => {
+        if (err) console.log(`received an error from chai: ${err.message}`);
         resolve(res.body);
       });
   });
@@ -159,28 +197,40 @@ describe('Document links', () => {
   /*
    * Test the /GET docs/pizzas route
    */
-  describe('/GET first from the collection should have no previous link but should have next link', () => {
-    it('it should get a document with a link to the next one and the previous one', done => {
+  describe('/GET pizzas starting from the first all the way to last following the links', () => {
+    it('gets first pizza with correct links', done => {
       getPizzaWithLinks(firstPizza).then(body => {
         body.next_id.should.eq(secondPizza);
         body.should.not.have.property('previous_id');
-        getPizzaWithLinks(secondPizza).then(body => {
-          body.previous_id.should.eq(firstPizza);
-          body.next_id.should.eq(thirdPizza);
-          getPizzaWithLinks(thirdPizza).then(body => {
-            body.previous_id.should.eq(secondPizza);
-            body.next_id.should.eq(fourthPizza);
-            getPizzaWithLinks(fourthPizza).then(body => {
-              body.previous_id.should.eq(thirdPizza);
-              body.next_id.should.eq(fifthPizza);
-              getPizzaWithLinks(fifthPizza).then(body => {
-                body.should.not.have.property('next_id');
-                body.previous_id.should.eq(fourthPizza);
-                done();
-              });
-            });
-          });
-        });
+        done();
+      });
+    });
+    it('gets 2nd pizza with correct links', done => {
+      getPizzaWithLinksInHeader(secondPizza).then(body => {
+        body.previous_id.should.eq(firstPizza);
+        body.next_id.should.eq(thirdPizza);
+        done();
+      });
+    });
+    it('gets third pizza with correct links', done => {
+      getPizzaWithLinks(thirdPizza).then(body => {
+        body.previous_id.should.eq(secondPizza);
+        body.next_id.should.eq(fourthPizza);
+        done();
+      });
+    });
+    it('gets fourth pizza with correct links', done => {
+      getPizzaWithLinksInHeader(fourthPizza).then(body => {
+        body.previous_id.should.eq(thirdPizza);
+        body.next_id.should.eq(fifthPizza);
+        done();
+      });
+    });
+    it('gets fifth pizza with correct links', done => {
+      getPizzaWithLinks(fifthPizza).then(body => {
+        body.should.not.have.property('next_id');
+        body.previous_id.should.eq(fourthPizza);
+        done();
       });
     });
   });
@@ -188,18 +238,40 @@ describe('Document links', () => {
   /*
    * Test the /GET docs/pizzas route
    */
-  describe('GET WITHOUT LINKS', () => {
-    it('it should get a document with no links', done => {
-      getPizzaWithoutLinks(firstPizza).then(body => {
-        getPizzaWithoutLinks(secondPizza).then(body => {
-          getPizzaWithoutLinks(thirdPizza).then(body => {
-            getPizzaWithoutLinks(fourthPizza).then(body => {
-              getPizzaWithoutLinks(fifthPizza).then(body => {
-                done();
-              });
-            });
-          });
-        });
+  describe('/GET each pizza one by one with links switched off or set to false, checks for no links', () => {
+    it('it should get first pizza with no links returned', done => {
+      getPizzaWithLinkOptionSetToFalse(firstPizza).then(body => {
+        body.should.not.have.property('next_id');
+        body.should.not.have.property('previous_id');
+        done();
+      });
+    });
+    it('it should get 2nd pizza with no links returned', done => {
+      getPizzaWithoutLinks(secondPizza).then(body => {
+        body.should.not.have.property('next_id');
+        body.should.not.have.property('previous_id');
+        done();
+      });
+    });
+    it('it should get 3rd pizza with no links returned', done => {
+      getPizzaWithoutLinksInHeader(thirdPizza).then(body => {
+        body.should.not.have.property('next_id');
+        body.should.not.have.property('previous_id');
+        done();
+      });
+    });
+    it('it should get 4th pizza with no links returned', done => {
+      getPizzaWithoutLinks(fourthPizza).then(body => {
+        body.should.not.have.property('next_id');
+        body.should.not.have.property('previous_id');
+        done();
+      });
+    });
+    it('it should get 5th pizza with no links returned', done => {
+      getPizzaWithoutLinksInHeader(fifthPizza).then(body => {
+        body.should.not.have.property('next_id');
+        body.should.not.have.property('previous_id');
+        done();
       });
     });
   });


### PR DESCRIPTION
The goal of this PR is to look for either with-links: true in the request header or withLink=true in the query string and then if either of those is set to true do the following:

- lookup the id of the doc that preceds the query and the id of the doc that comes next

- if there is a preceeding document then the value previous_id will contain the id of that document

- if there is a document that comes after the value next_id will contain the id of that document

- if either of the above are not found i.e. no preceeding or subsequent document then those values will be absent from the server response

I have not applied the logic to inhertiable docs as this feature is not used yet