### PR TITLE
[CAMPSI-MONO] - Don't response an error if user not create

### DIFF
--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -312,8 +312,8 @@ module.exports.createResetPasswordToken = function (req, res) {
       });
       return res.json({ success: true });
     })
-    .catch(err => {
-      return helpers.error(res, err);
+    .catch(() => {
+      return res.json({ success: true });
     });
 };
 


### PR DESCRIPTION
Actually if user not exist in forget-password, campsi return an error. I changed the behaviour and now campsi always return success even if the user don't exist.

Like this no one can try one by one email.