### PR TITLE
buildLink default export from buildLinks file

### DIFF
--- a/lib/modules/buildLink.js
+++ b/lib/modules/buildLink.js
@@ -13,20 +13,3 @@ module.exports = function buildLink(req, page, keptParams) {
     .join('&');
   return '{0}://{1}{2}?{3}'.format(req.protocol, req.get('host'), path, query);
 };
-
-module.exports.buildSingleDocumentLink = function (req, id) {
-  const pathFragments = req.path.split('/');
-  let path = req.baseUrl;
-
-  // path can be either /resource/id or /resource/id/state
-  if (pathFragments.length >= 2) {
-    path += '/' + pathFragments[1] + '/' + id;
-
-    // this should be the state if it's present
-    if (pathFragments.length === 4) {
-      path += '/' + pathFragments[3];
-    }
-  }
-
-  return '{0}://{1}{2}'.format(req.protocol, req.get('host'), path);
-};

--- a/lib/modules/buildLink.js
+++ b/lib/modules/buildLink.js
@@ -14,7 +14,7 @@ module.exports = function buildLink(req, page, keptParams) {
   return '{0}://{1}{2}?{3}'.format(req.protocol, req.get('host'), path, query);
 };
 
-module.exports = function buildSingleDocumentLink(req, id) {
+module.exports.buildSingleDocumentLink = function (req, id) {
   const pathFragments = req.path.split('/');
   let path = req.baseUrl;
 

--- a/lib/modules/buildSingleDocumentLink.js
+++ b/lib/modules/buildSingleDocumentLink.js
@@ -1,0 +1,16 @@
+module.exports = function buildSingleDocumentLink(req, id) {
+  const pathFragments = req.path.split('/');
+  let path = req.baseUrl;
+
+  // path can be either /resource/id or /resource/id/state
+  if (pathFragments.length >= 2) {
+    path += '/' + pathFragments[1] + '/' + id;
+
+    // this should be the state if it's present
+    if (pathFragments.length === 4) {
+      path += '/' + pathFragments[3];
+    }
+  }
+
+  return '{0}://{1}{2}'.format(req.protocol, req.get('host'), path);
+};

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -155,7 +155,7 @@ module.exports.getDoc = function (req, res) {
         const links = [];
 
         Object.entries(nav).forEach(([rel, id]) => {
-          links.push(`<${buildSingleDocumentLink(req, id)}>; rel="${rel}"`);
+          links.push(`<${buildSingleDocumentLink.buildSingleDocumentLink(req, id)}>; rel="${rel}"`);
         });
 
         const headersKeys = [];

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -3,7 +3,6 @@ const resourceService = require('./services/resource');
 const documentService = require('./services/document');
 const userService = require('./services/user');
 const buildLink = require('../../../lib/modules/buildLink');
-const buildSingleDocumentLink = require('../../../lib/modules/buildLink');
 const debug = require('debug')('campsi:docs');
 const { ObjectId } = require('mongodb');
 const ValidationError = require('../../../lib/errors/ValidationError');
@@ -155,7 +154,7 @@ module.exports.getDoc = function (req, res) {
         const links = [];
 
         Object.entries(nav).forEach(([rel, id]) => {
-          links.push(`<${buildSingleDocumentLink.buildSingleDocumentLink(req, id)}>; rel="${rel}"`);
+          links.push(`<${buildLink.buildSingleDocumentLink(req, id)}>; rel="${rel}"`);
         });
 
         const headersKeys = [];

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -3,7 +3,7 @@ const resourceService = require('./services/resource');
 const documentService = require('./services/document');
 const userService = require('./services/user');
 const buildLink = require('../../../lib/modules/buildLink');
-const debug = require('debug')('campsi:docs');
+const buildSingleDocumentLink = require('../../../lib/modules/buildSingleDocumentLink');
 const { ObjectId } = require('mongodb');
 const ValidationError = require('../../../lib/errors/ValidationError');
 
@@ -154,7 +154,7 @@ module.exports.getDoc = function (req, res) {
         const links = [];
 
         Object.entries(nav).forEach(([rel, id]) => {
-          links.push(`<${buildLink.buildSingleDocumentLink(req, id)}>; rel="${rel}"`);
+          links.push(`<${buildSingleDocumentLink(req, id)}>; rel="${rel}"`);
         });
 
         const headersKeys = [];


### PR DESCRIPTION
Goal of this PR is to fix the buldLink test that was failing due to multiple functions being exported from the same file. buildLink is now the default export and exisiting functionality should be preserved