### PR TITLE
feat: stripe maxNetworkRetries set

### DIFF
--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -52,7 +52,9 @@ const defaultHandler = res => (err, obj) => {
 
 module.exports = class StripeBillingService extends CampsiService {
   initialize() {
-    this.stripe = require('stripe')(this.options.secret_key);
+    this.stripe = require('stripe')(this.options.secret_key, {
+      maxNetworkRetries: 2
+    });
     const stripe = this.stripe;
 
     this.router.use((req, res, next) => {


### PR DESCRIPTION
https://github.com/stripe/stripe-node#network-retries
considered as good practice by stripe to avoid object lock timeout: https://stripe.com/docs/rate-limits#object-lock-timeouts

> This object cannot be accessed right now because another API request or Stripe process is currently accessing it. If you see this error intermittently, retry the request. If you see this error frequently and are making multiple concurrent requests to a single object, make your requests serially or at a lower rate.