### PR TITLE
Jameslotery/axe 952 docs tokens

### DIFF
--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -218,3 +218,17 @@ module.exports.delDocUser = function (req, res) {
     .then(() => req.service.emit('document/users/removed', getEmitPayload(req, { removedUserId: req.params.user })))
     .catch(err => helpers.notFound(res, err));
 };
+
+module.exports.lockDocument = function (req, res) {
+  try {
+    documentService.lockDocument(req.resource, req.state, req.filter, req.query?.lockTimeout, req.user, req).then(lock => {
+      if (lock) {
+        helpers.json(res, lock);
+      } else {
+        helpers.conflict(res);
+      }
+    });
+  } catch (err) {
+    helpers.badRequest(res, err);
+  }
+};

--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -30,11 +30,11 @@ module.exports = class DocsService extends CampsiService {
     this.router.param('resource', param.attachResource(service.options));
     this.router.get('/', handlers.getResources);
     this.router.get('/:resource', handlers.getDocuments);
-    this.router.post('/:resource/:id/locks/lock', handlers.lockDocument);
+    this.router.post('/:resource/:id/locks', handlers.lockDocument);
     this.router.get('/:resource/:id/users', handlers.getDocUsers);
     this.router.post('/:resource/:id/users', handlers.postDocUser);
     this.router.delete('/:resource/:id/users/:user', handlers.delDocUser);
-    this.router.post('/:resource/:id/:state/locks/lock', handlers.lockDocument);
+    this.router.post('/:resource/:id/:state/locks', handlers.lockDocument);
     this.router.get('/:resource/:id/:state', handlers.getDoc);
     this.router.get('/:resource/:id', handlers.getDoc);
     this.router.post('/:resource/:state', handlers.postDoc);

--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -30,9 +30,11 @@ module.exports = class DocsService extends CampsiService {
     this.router.param('resource', param.attachResource(service.options));
     this.router.get('/', handlers.getResources);
     this.router.get('/:resource', handlers.getDocuments);
+    this.router.post('/:resource/:id/locks/lock', handlers.lockDocument);
     this.router.get('/:resource/:id/users', handlers.getDocUsers);
     this.router.post('/:resource/:id/users', handlers.postDocUser);
     this.router.delete('/:resource/:id/users/:user', handlers.delDocUser);
+    this.router.post('/:resource/:id/:state/locks/lock', handlers.lockDocument);
     this.router.get('/:resource/:id/:state', handlers.getDoc);
     this.router.get('/:resource/:id', handlers.getDoc);
     this.router.post('/:resource/:state', handlers.postDoc);
@@ -50,18 +52,18 @@ module.exports = class DocsService extends CampsiService {
       csdVisibility(ajvReader);
       async.eachOf(
         service.options.resources,
-        function(resource, name, cb) {
+        function (resource, name, cb) {
           Object.assign(resource, service.options.classes[resource.class]);
           resource.collection = server.db.collection('docs.{0}.{1}'.format(service.path, name));
           $RefParser
             .dereference(service.config.optionsBasePath + '/', resource.schema, {})
-            .then(function(schema) {
+            .then(function (schema) {
               resource.schema = schema;
               resource.validate = ajvWriter.compile(schema);
               resource.filter = ajvWriter.compile(schema);
               cb();
             })
-            .catch(function(error) {
+            .catch(function (error) {
               debug(error);
               cb();
             });

--- a/services/docs/lib/param.js
+++ b/services/docs/lib/param.js
@@ -43,7 +43,7 @@ module.exports.attach = (req, res, next, options) => {
 
     // check if the document is locked by someone else if we are trying to modify it
     const lockChek = new Promise((resolve, reject) => {
-      if (req.method === 'PUT' || req.method === 'POST' || req.method === 'PATCH' || req.method === 'DELETE') {
+      if (['PUT', 'POST', 'PATCH', 'DELETE'].some(method => req.method.includes(method))) {
         documentService
           .isDocumentLockedByOtherUser(
             req.state,

--- a/services/docs/lib/param.js
+++ b/services/docs/lib/param.js
@@ -45,7 +45,13 @@ module.exports.attach = (req, res, next, options) => {
     const lockChek = new Promise((resolve, reject) => {
       if (req.method === 'PUT' || req.method === 'POST' || req.method === 'PATCH' || req.method === 'DELETE') {
         documentService
-          .isDocumentLockedByOtherUser(req.state, req.filter, req.user, req.service.options.editLock, req.db)
+          .isDocumentLockedByOtherUser(
+            req.state,
+            req.filter,
+            req.user,
+            req.service.options?.editLock || { collectionName: 'dock-lock', lockTimeoutSeconds: 3600 },
+            req.db
+          )
           .then(lock => {
             if (lock) {
               reject(helpers.unauthorized(res));

--- a/services/docs/lib/param.js
+++ b/services/docs/lib/param.js
@@ -1,10 +1,11 @@
 const helpers = require('../../../lib/modules/responseHelpers');
 const createObjectId = require('../../../lib/modules/createObjectId');
 const { can } = require('./modules/permissions');
+const documentService = require('./services/document');
 const { getValidGroupsFromString } = require('../../../lib/modules/groupsHelpers');
 const createError = require('http-errors');
 
-module.exports.attachResource = function(options) {
+module.exports.attachResource = function (options) {
   return (req, res, next) => {
     this.attach(req, res, next, options);
   };
@@ -40,13 +41,33 @@ module.exports.attach = (req, res, next, options) => {
 
     req.groups = req.query?.groups ? getValidGroupsFromString(req.query.groups) : [];
 
-    // USER can access RESOURCE/FILTER with METHOD/STATE ?
-    try {
-      const filter = can(req.user, req.resource, req.method, req.state);
-      req.filter = { ...req.filter, ...filter };
-      next();
-    } catch (err) {
-      throw new createError.Unauthorized(err.message);
-    }
+    // check if the document is locked by someone else if we are trying to modify it
+    const lockChek = new Promise((resolve, reject) => {
+      if (req.method === 'PUT' || req.method === 'POST' || req.method === 'PATCH' || req.method === 'DELETE') {
+        documentService
+          .isDocumentLockedByOtherUser(req.state, req.filter, req.user, req.service.options.editLock, req.db)
+          .then(lock => {
+            if (lock) {
+              reject(helpers.unauthorized(res));
+            }
+            resolve();
+          });
+      } else resolve();
+    });
+
+    lockChek
+      .then(() => {
+        try {
+          const filter = can(req.user, req.resource, req.method, req.state);
+          req.filter = { ...req.filter, ...filter };
+
+          next();
+        } catch (err) {
+          return helpers.unauthorized(res);
+        }
+      })
+      .catch(err => {
+        return err;
+      });
   }
 };

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -14,6 +14,80 @@ const getRequestedStatesFromQuery = (resource, query) => {
   return query.states ? query.states.split(',') : Object.keys(resource.states);
 };
 
+const getDocumentLock = function (state, filter, lockCollection) {
+  return new Promise((resolve, reject) => {
+    if (!filter._id) {
+      return resolve(undefined);
+    }
+
+    const match = { documentId: filter._id, [`${state}`]: { $exists: true } };
+    lockCollection.findOne(match, (err, doc) => {
+      if (err) reject(err);
+      resolve(doc);
+    });
+  });
+};
+
+module.exports.isDocumentLockedByOtherUser = function (state, filter, user, editLock, db) {
+  return new Promise((resolve, reject) => {
+    getDocumentLock(state, filter, db.collection(editLock.collectionName)).then(lock => {
+      if (!lock) return resolve(false);
+
+      const lockedBy = lock?.[`${state}`];
+
+      if (!lockedBy) return resolve(false);
+
+      const lockExpired = new Date().getTime() > new Date(lockedBy.timeout).getTime();
+      const sameUser = new ObjectId(user?._id).equals(lockedBy.userId);
+
+      resolve(!sameUser && !lockExpired);
+    });
+  });
+};
+
+module.exports.lockDocument = async function (resource, state, filter, tokenTimeout, user, req) {
+  const { editLock } = req.service.options;
+  const lockCollection = req.db.collection(editLock.collectionName);
+  const timeout = new Date();
+
+  tokenTimeout
+    ? timeout.setTime(timeout.getTime() + tokenTimeout * 1000)
+    : timeout.setTime(timeout.getTime() + editLock.lockTimeoutSeconds * 1000);
+
+  // look for an existing lock
+  const lock = await getDocumentLock(state, filter, lockCollection);
+
+  // lock if no lock found
+  if (!lock) {
+    const lock = {
+      documentId: filter._id,
+      [`${state}`]: {
+        timeout,
+        userId: user._id
+      }
+    };
+
+    const result = await lockCollection.insertOne(lock);
+    return result;
+  } else if (new ObjectId(user._id).equals(lock[`${state}`].userId) || lock[`${state}`].timeout < new Date()) {
+    // update / overwrite the existing lock because it belongs to the same user
+    // for the same doc state or the old has lock expired
+    const find = { documentId: filter._id, [`${state}`]: { $exists: true } };
+    const update = {
+      $set: {
+        [`${state}.timeout`]: timeout,
+        [`${state}.userId`]: user._id
+      }
+    };
+
+    // const update = { [`${state}.timeout`]: timeout, [`${state}.userId`]: user._id };
+    const result = await lockCollection.findOneAndUpdate(find, update);
+    return result;
+  } else {
+    return undefined;
+  }
+};
+
 module.exports.getDocuments = function (resource, filter, user, query, state, sort, pagination, resources) {
   const queryBuilderOptions = {
     resource,

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -79,7 +79,6 @@ module.exports.lockDocument = async function (resource, state, filter, tokenTime
       }
     };
 
-    // const update = { [`${state}.timeout`]: timeout, [`${state}.userId`]: user._id };
     const result = await lockCollection.findOneAndUpdate(find, update);
     return result;
   } else {

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -46,7 +46,7 @@ module.exports.isDocumentLockedByOtherUser = function (state, filter, user, edit
 };
 
 module.exports.lockDocument = async function (resource, state, filter, tokenTimeout, user, req) {
-  const { editLock } = req.service.options;
+  const editLock = req.service.options?.editLock || { collectionName: 'dock-lock', lockTimeoutSeconds: 3600 };
   const lockCollection = req.db.collection(editLock.collectionName);
   const timeout = new Date();
 

--- a/test/docs/config/options/docs.js
+++ b/test/docs/config/options/docs.js
@@ -223,5 +223,9 @@ module.exports = {
       class: 'test-class',
       schema: { $ref: '../../../schemas/document.schema.json' }
     }
+  },
+  editLock: {
+    collectionName: 'dock-lock',
+    lockTimeoutSeconds: 3600
   }
 };

--- a/test/docs/lock-document.js
+++ b/test/docs/lock-document.js
@@ -45,6 +45,7 @@ describe('locks', () => {
   describe('Document lock tests', () => {
     let userToken;
     let docId;
+    let privateDocId;
 
     it('it should return the created object', async () => {
       const campsi = context.campsi;
@@ -129,6 +130,91 @@ describe('locks', () => {
         .send({ name: '5 cheeses' });
 
       res.should.have.status(401);
+    });
+
+    it('it should let us create a working draft pizza doc', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .post('/docs/pizzas/working_draft')
+        .set('Authorization', 'Bearer ' + nownerToken)
+        .send({ name: '6 cheeses' });
+
+      res.should.have.status(200);
+
+      privateDocId = res.body.id;
+    });
+
+    it('it should let us update the working_draft pizza', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .put(`/docs/pizzas/${privateDocId}/working_draft`)
+        .set('Authorization', 'Bearer ' + nownerToken)
+        .send({ name: '7 cheeses' });
+
+      res.should.have.status(200);
+    });
+
+    it('it should let us lock the working_draft pizza', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .post(`/docs/pizzas/${privateDocId}/working_draft/locks/lock`)
+        .set('Authorization', 'Bearer ' + nownerToken);
+
+      res.should.have.status(200);
+    });
+
+    it('it should let us update the locked the working_draft pizza', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .put(`/docs/pizzas/${privateDocId}/working_draft`)
+        .set('Authorization', 'Bearer ' + nownerToken)
+        .send({ name: '8 cheeses' });
+
+      res.should.have.status(200);
+    });
+
+    it('it should block us from updating the locked the working_draft pizza', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .put(`/docs/pizzas/${privateDocId}/working_draft`)
+        .set('Authorization', 'Bearer ' + userToken)
+        .send({ name: '9 cheeses' });
+
+      res.should.have.status(401);
+    });
+
+    it('it should let us modify the public version', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .put(`/docs/pizzas/${privateDocId}`)
+        .set('Authorization', 'Bearer ' + userToken)
+        .send({ name: '9 cheeses' });
+
+      res.should.have.status(200);
+    });
+
+    it('it should let us lock the public version', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .post(`/docs/pizzas/${privateDocId}/locks/lock`)
+        .set('Authorization', 'Bearer ' + userToken)
+        .send({ name: '9 cheeses' });
+
+      res.should.have.status(200);
     });
   });
 });

--- a/test/docs/lock-document.js
+++ b/test/docs/lock-document.js
@@ -1,0 +1,134 @@
+/* eslint-disable no-unused-expressions */
+process.env.NODE_CONFIG_DIR = './test/docs/config';
+process.env.NODE_ENV = 'test';
+
+// Require the dev-dependencies
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const format = require('string-format');
+const createUser = require('../helpers/createUser');
+const setupBeforeEach = require('../helpers/setupBeforeEach');
+const config = require('config');
+let nownerToken;
+
+chai.should();
+format.extend(String.prototype);
+chai.use(chaiHttp);
+
+const owner = {
+  displayName: 'Document Owner',
+  email: 'owner@agilitation.fr',
+  username: 'owner',
+  password: 'signup!'
+};
+
+const nowner = {
+  displayName: 'Document NOwner',
+  email: 'nowner@agilitation.fr',
+  username: 'nowner',
+  password: 'signup!'
+};
+
+const services = {
+  Auth: require('../../services/auth/lib'),
+  Docs: require('../../services/docs/lib')
+};
+
+describe('locks', () => {
+  const context = {};
+  before(setupBeforeEach(config, services, context));
+
+  after(done => {
+    context.server.close(done);
+  });
+
+  describe('Document lock tests', () => {
+    let userToken;
+    let docId;
+
+    it('it should return the created object', async () => {
+      const campsi = context.campsi;
+
+      const token = await createUser(chai, campsi, owner);
+
+      userToken = token;
+      let res = await chai
+        .request(campsi.app)
+        .post('/docs/pizzas')
+        .set('Authorization', 'Bearer ' + token)
+        .send({ name: 'renne' });
+
+      docId = res.body.id;
+      res = await chai
+        .request(campsi.app)
+        .post(`/docs/pizzas/${res.body.id}/locks/lock`)
+        .set('Authorization', 'Bearer ' + token);
+
+      res.should.have.status(200);
+    });
+
+    it('it should let us lock the document because we hold the original lock', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .post(`/docs/pizzas/${docId}/locks/lock`)
+        .set('Authorization', 'Bearer ' + userToken);
+
+      res.should.have.status(200);
+      res.should.be.json;
+    });
+
+    it('it should let us lock the document and set a short timeout', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .post(`/docs/pizzas/${docId}/locks/lock?lockTimeout=1`)
+        .set('Authorization', 'Bearer ' + userToken);
+
+      res.should.have.status(200);
+      res.should.be.json;
+    });
+
+    it('it should let us lock the document because the previous lock has expired', async () => {
+      const campsi = context.campsi;
+
+      nownerToken = await createUser(chai, campsi, nowner);
+
+      // wait 1 second to let previous lock expire
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      const res = await chai
+        .request(campsi.app)
+        .put(`/docs/pizzas/${docId}`)
+        .set('Authorization', 'Bearer ' + nownerToken)
+        .send({ name: '4 cheeses' });
+
+      res.should.have.status(200);
+    });
+
+    it('it should lock the document because previous lock has expired', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .post(`/docs/pizzas/${docId}/locks/lock`)
+        .set('Authorization', 'Bearer ' + userToken);
+
+      res.should.have.status(200);
+    });
+
+    it('it should not update the document because somone else holds the lock', async () => {
+      const campsi = context.campsi;
+
+      const res = await chai
+        .request(campsi.app)
+        .put(`/docs/pizzas/${docId}`)
+        .set('Authorization', 'Bearer ' + nownerToken)
+        .send({ name: '5 cheeses' });
+
+      res.should.have.status(401);
+    });
+  });
+});

--- a/test/docs/lock-document.js
+++ b/test/docs/lock-document.js
@@ -62,7 +62,7 @@ describe('locks', () => {
       docId = res.body.id;
       res = await chai
         .request(campsi.app)
-        .post(`/docs/pizzas/${res.body.id}/locks/lock`)
+        .post(`/docs/pizzas/${res.body.id}/locks`)
         .set('Authorization', 'Bearer ' + token);
 
       res.should.have.status(200);
@@ -73,7 +73,7 @@ describe('locks', () => {
 
       const res = await chai
         .request(campsi.app)
-        .post(`/docs/pizzas/${docId}/locks/lock`)
+        .post(`/docs/pizzas/${docId}/locks`)
         .set('Authorization', 'Bearer ' + userToken);
 
       res.should.have.status(200);
@@ -85,7 +85,7 @@ describe('locks', () => {
 
       const res = await chai
         .request(campsi.app)
-        .post(`/docs/pizzas/${docId}/locks/lock?lockTimeout=1`)
+        .post(`/docs/pizzas/${docId}/locks?lockTimeout=1`)
         .set('Authorization', 'Bearer ' + userToken);
 
       res.should.have.status(200);
@@ -114,7 +114,7 @@ describe('locks', () => {
 
       const res = await chai
         .request(campsi.app)
-        .post(`/docs/pizzas/${docId}/locks/lock`)
+        .post(`/docs/pizzas/${docId}/locks`)
         .set('Authorization', 'Bearer ' + userToken);
 
       res.should.have.status(200);
@@ -163,7 +163,7 @@ describe('locks', () => {
 
       const res = await chai
         .request(campsi.app)
-        .post(`/docs/pizzas/${privateDocId}/working_draft/locks/lock`)
+        .post(`/docs/pizzas/${privateDocId}/working_draft/locks`)
         .set('Authorization', 'Bearer ' + nownerToken);
 
       res.should.have.status(200);
@@ -210,7 +210,7 @@ describe('locks', () => {
 
       const res = await chai
         .request(campsi.app)
-        .post(`/docs/pizzas/${privateDocId}/locks/lock`)
+        .post(`/docs/pizzas/${privateDocId}/locks`)
         .set('Authorization', 'Bearer ' + userToken)
         .send({ name: '9 cheeses' });
 

--- a/test/docs/lock-document.js
+++ b/test/docs/lock-document.js
@@ -62,7 +62,7 @@ describe('locks', () => {
       docId = res.body.id;
       res = await chai
         .request(campsi.app)
-        .post(`/docs/pizzas/${res.body.id}/locks`)
+        .post(`/docs/pizzas/${docId}/locks`)
         .set('Authorization', 'Bearer ' + token);
 
       res.should.have.status(200);


### PR DESCRIPTION

These changes do the following:

1. For all update methods (PUT, POST, PATCH, DELETE) in the docs service check to see if there is a lock on the document/state in the database held by another user.
2. If there is a valid lock held by another user a 401 error will be returned
3. The new methods look for a section in service options with the following format: 
editLock: {
    collectionName: 'dock-lock',
    lockTimeoutSeconds: 3600
  }
4. If editLock is not present default values are used (dock-lock and 3600)
5. If a user tries to lock a document and the previous lock has expired it will overwrite the existing lock
6. User who hold the lock can continue to update the document as normal

Please note I have placed the lock check just before the can() method in the params  method as the catch around the can block would never catch the exception thrown from the can function.

We need methods to delete and list the locks so this branch should not be merged until they have been added