### PR TITLE
feat: handle virtual properties for docs service

### DIFF
--- a/services/docs/lib/modules/queryBuilder.js
+++ b/services/docs/lib/modules/queryBuilder.js
@@ -234,6 +234,9 @@ module.exports.create = function createDoc(options) {
   const state = getStateFromOptions(options);
 
   return new Promise((resolve, reject) => {
+    if (options.resource.virtualProperties) {
+      Object.keys(options.resource.virtualProperties).map(prop => delete options.data[prop]);
+    }
     return validate(options.resource, options.data, state.validate)
       .catch(reject)
       .then(() => {

--- a/services/docs/lib/modules/queryBuilder.js
+++ b/services/docs/lib/modules/queryBuilder.js
@@ -234,9 +234,6 @@ module.exports.create = function createDoc(options) {
   const state = getStateFromOptions(options);
 
   return new Promise((resolve, reject) => {
-    if (options.resource.virtualProperties) {
-      Object.keys(options.resource.virtualProperties).map(prop => delete options.data[prop]);
-    }
     return validate(options.resource, options.data, state.validate)
       .catch(reject)
       .then(() => {

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -153,7 +153,7 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
             returnData.creator = doc.creator;
           }
 
-          this.addVirtualProperties(resource, returnData.data);
+          addVirtualProperties(resource, returnData.data);
 
           return returnData;
         });
@@ -169,7 +169,7 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
 };
 
 module.exports.createDocument = function (resource, data, state, user, parentId, groups) {
-  this.removeVirtualProperties(resource, data);
+  removeVirtualProperties(resource, data);
   return new Promise((resolve, reject) => {
     builder
       .create({
@@ -209,7 +209,7 @@ module.exports.createDocument = function (resource, data, state, user, parentId,
 };
 
 module.exports.setDocument = function (resource, filter, data, state, user) {
-  this.removeVirtualProperties(resource, data);
+  removeVirtualProperties(resource, data);
   return new Promise((resolve, reject) => {
     builder
       .update({
@@ -242,7 +242,7 @@ module.exports.setDocument = function (resource, filter, data, state, user) {
 };
 
 module.exports.patchDocument = async (resource, filter, data, state, user) => {
-  this.removeVirtualProperties(resource, data);
+  removeVirtualProperties(resource, data);
   const update = await builder.patch({ resource, data, state, user });
 
   const updateDoc = await resource.collection.findOneAndUpdate(filter, update, {
@@ -586,7 +586,7 @@ const prepareGetDocument = settings => {
   const currentState = doc.states[state] || {};
   const allowedStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'GET', doc);
 
-  this.addVirtualProperties(resource, currentState.data);
+  addVirtualProperties(resource, currentState.data);
 
   return {
     id: doc._id,
@@ -601,13 +601,13 @@ const prepareGetDocument = settings => {
   };
 };
 
-module.exports.removeVirtualProperties = (resource, data) => {
+const removeVirtualProperties = (resource, data) => {
   if (resource.virtualProperties) {
     Object.keys(resource.virtualProperties).map(prop => delete data[prop]);
   }
 };
 
-module.exports.addVirtualProperties = (resource, data) => {
+const addVirtualProperties = (resource, data) => {
   if (resource.virtualProperties && data) {
     Object.entries(resource.virtualProperties).map(([prop, compute]) => (data[prop] = compute(data)));
   }


### PR DESCRIPTION
When declaring resource, you can add virtual properties, for instance:
```javascript
organizations: {
              label: 'organization',
              class: 'entry',
              schema: { $ref: 'vault/organization.schema.json' },
              virtualProperties: {
                emailDomain: orga => orga.email?.split('@').pop()
              }
            },
```

virtual properties are computed on GET and removed (if presents) on POST/PUT/PATCH