### PR TITLE
added semantic release and associated config

### DIFF
--- a/.github/worklows/release-package.yml
+++ b/.github/worklows/release-package.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+#push:
+#    branches: [main, beta]
+  push:
+    branches: [master, beta]
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 16.x
+    - name: Install dependencies
+      run: npx ci
+    - name: Install semantic-release extra plugins
+      run: npm install --save-dev @semantic-release/changelog @semantic-release/git
+    - name: Test
+      run: npm run test:unit --if-present
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npx semantic-release
+

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [1, 'always', 50]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "campsi",
-  "version": "1.1.4",
+  "version": "0.0.0-semantic-release",
   "description": "Configurable API for managing and publishing document-oriented content",
   "main": "index.js",
   "scripts": {

--- a/release-config.js
+++ b/release-config.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-template-curly-in-string */
+module.exports = {
+  branches: [
+    'master',
+    {
+      name: 'beta',
+      prerelease: true
+    }
+  ],
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    {
+      preset: 'eslint',
+      releaseRules: [
+        { scope: 'no-release', release: false },
+        { type: '', release: 'patch' }
+      ]
+    },
+    '@semantic-release/release-notes-generator',
+    [
+      '@semantic-release/changelog',
+      {
+        changelogFile: 'CHANGELOG.md'
+      }
+    ],
+    '@semantic-release/npm',
+    '@semantic-release/github',
+    [
+      '@semantic-release/git',
+      {
+        assets: ['CHANGELOG.md', 'dist/**'],
+        message: 'chore(release): set `package.json` to ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
+      }
+    ]
+  ]
+};


### PR DESCRIPTION
The changes in this PR will do the following:
1. enforce semantic versioning syntax on commits (fix:, feature, etc)
2. automatically push a new version of campsi to the NPM respository. The version umber will be incremented based on the commit message like so:

if feat: is present in the commit message then the minor version will be bumped up
if only fix: is present in the commit message then the patch version will be bumped up
if perf or BREAKING CHANGE is present in the commit message then the major version number will be bumped