### PR TITLE
set default pinoHttp log level to silent

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -21,7 +21,7 @@ function ServiceException(path, service, message) {
 }
 
 const pinoHttpDefaultOptions = {
-  level: 'error',
+  level: 'silent',
   formatters: {
     level(label) {
       return { level: label };


### PR DESCRIPTION
The goal of the PR was to reduce the noise produced by pinoHttp when running tests, especially tests that were mean't to fail. The default level has been set to silent. This can be overriden by creating a pino object in the service configuration file with the appropriate options set.