### PR TITLE
Jameslotery/fix service name config

### DIFF
--- a/services/auth/lib/modules/collectionNames.js
+++ b/services/auth/lib/modules/collectionNames.js
@@ -3,11 +3,11 @@
 const config = require('config');
 
 function getUsersCollectionName() {
-  return config.services.auth.options.collectionName || '__users__';
+  return config?.services?.auth?.options?.collectionName || '__users__';
 }
 
 function getSessionCollectionName() {
-  return config.services.auth.options.session.collectionName || '__sessions__';
+  return config?.services?.auth?.options?.session?.collectionName || '__sessions__';
 }
 
 module.exports = {

--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -48,10 +48,10 @@ module.exports = class DocsService extends CampsiService {
     this.router.delete('/:resource/:id', handlers.delDoc);
     this.router.delete('/:resource/:id/:state', handlers.delDoc);
     return new Promise(resolve => {
-      const ajvWriter = new Ajv({ useAssign: true, strictTuples: false });
+      const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: 'log' });
       addFormats(ajvWriter);
       csdAssign(ajvWriter);
-      const ajvReader = new Ajv({ useVisibility: true, strictTuples: false });
+      const ajvReader = new Ajv({ useVisibility: true, strictTuples: false, strict: 'log' });
       addFormats(ajvReader);
       csdVisibility(ajvReader);
       async.eachOf(

--- a/services/notifications/index.js
+++ b/services/notifications/index.js
@@ -3,6 +3,7 @@ const CampsiService = require('../../lib/service');
 const debug = require('debug')('campsi:notifications');
 const handlers = require('./handlers');
 const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
 const csdAssign = require('../../lib/keywords/csdAssign');
 const csdVisibility = require('../../lib/keywords/csdVisibility');
 const $RefParser = require('json-schema-ref-parser');
@@ -32,10 +33,12 @@ module.exports = class NotificationsService extends CampsiService {
     this.router.deleteAsync('/:resource/:id', handlers.deleteNotification);
 
     return new Promise(resolve => {
-      const ajvWriter = new Ajv({ useAssign: true, strictTuples: false });
+      const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: 'log' });
       csdAssign(ajvWriter);
-      const ajvReader = new Ajv({ useVisibility: true, strictTuples: false });
+      addFormats(ajvWriter);
+      const ajvReader = new Ajv({ useVisibility: true, strictTuples: false, strict: 'log' });
       csdVisibility(ajvReader);
+      addFormats(ajvReader);
 
       async.eachOf(
         service.options.resources,


### PR DESCRIPTION
PR fixes two issues in CAMPSI:

1. a bug in CAMPSI whereby if the users and sessions collections was not present in the config file Campsi would crash on startup
2. AJV 8.x requires formats to be added from an external package (ajv-formats). 
