### PR TITLE
feat: delete any document lock if admin

### DIFF
--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -35,7 +35,13 @@ function dispatchError(res, error) {
 
 module.exports.deleteLock = async function (req, res) {
   try {
-    await documentService.deleteLock(req?.params?.lock, req.user, getDocumentLockServiceOptions(req), req.db);
+    await documentService.deleteLock(
+      req?.params?.lock,
+      req.user,
+      getDocumentLockServiceOptions(req),
+      req.db,
+      req?.query?.surrogateId
+    );
     return helpers.json(res);
   } catch (ex) {
     dispatchError(res, ex);

--- a/services/docs/lib/param.js
+++ b/services/docs/lib/param.js
@@ -48,7 +48,7 @@ module.exports.attach = (req, res, next, options) => {
         documentService
           .isDocumentLockedByOtherUser(req.state, req.filter, req.user, getDocumentLockServiceOptions(req), req.db)
           .then(lock => {
-            if (lock) {
+            if (lock && !req?.user?.isAdmin) {
               reject(helpers.unauthorized(res));
             }
             resolve();


### PR DESCRIPTION
Goal of this PR was to allow admins to delete locks on a document that belonged to other users. A non admin user should not be able to delete  a lock that belongs to someone else.