### PR TITLE
fix: turn off strict mode in AJV

### DIFF
--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -49,10 +49,10 @@ module.exports = class DocsService extends CampsiService {
     this.router.delete('/:resource/:id/:state', handlers.delDoc);
     this.router.delete('/:resource/:id/locks/:lock', handlers.deleteLock);
     return new Promise(resolve => {
-      const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: 'log' });
+      const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: false });
       addFormats(ajvWriter);
       csdAssign(ajvWriter);
-      const ajvReader = new Ajv({ useVisibility: true, strictTuples: false, strict: 'log' });
+      const ajvReader = new Ajv({ useVisibility: true, strictTuples: false, strict: false });
       addFormats(ajvReader);
       csdVisibility(ajvReader);
       async.eachOf(

--- a/services/notifications/index.js
+++ b/services/notifications/index.js
@@ -33,10 +33,10 @@ module.exports = class NotificationsService extends CampsiService {
     this.router.deleteAsync('/:resource/:id', handlers.deleteNotification);
 
     return new Promise(resolve => {
-      const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: 'log' });
+      const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: false });
       csdAssign(ajvWriter);
       addFormats(ajvWriter);
-      const ajvReader = new Ajv({ useVisibility: true, strictTuples: false, strict: 'log' });
+      const ajvReader = new Ajv({ useVisibility: true, strictTuples: false, strict: false });
       csdVisibility(ajvReader);
       addFormats(ajvReader);
 


### PR DESCRIPTION
Fairly self explanatory - Ajv's strict mode has been turned off so that there aren't loads of warning messages on the screen / in the logs at run time. AJV Errors will still cause the API to fail.