### PR TITLE
Jameslotery/dev 2017

### DIFF
--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -401,6 +401,14 @@ function acceptInvitation(req, res) {
   );
 }
 
+async function removeGroupsFromUser(filter, update, db) {
+  try {
+    await db.collection(getUsersCollectionName()).updateOne(filter, update);
+  } catch (ex) {
+    debug(ex);
+  }
+}
+
 function addGroupsToUser(req, res) {
   if (!req.user) {
     return helpers.unauthorized(res);
@@ -475,5 +483,6 @@ module.exports = {
   inviteUser,
   acceptInvitation,
   addGroupsToUser,
-  extractUserPersonalData
+  extractUserPersonalData,
+  removeGroupsFromUser
 };

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -54,6 +54,7 @@ module.exports = class AuthService extends CampsiService {
     router.put('/me', handlers.updateMe);
     router.patch('/me', handlers.patchMe);
     router.post('/me/groups/:groups', handlers.addGroupsToUser);
+    router.delete('/me/groups/:groups', handlers.removeGroupsFromUser);
     router.get('/anonymous', handlers.createAnonymousUser);
     router.get('/logout', handlers.logout);
     router.post('/invitations', handlers.inviteUser);
@@ -94,5 +95,9 @@ module.exports = class AuthService extends CampsiService {
       return map;
     }, {});
     return userIds.map(userId => map[userId] || userId);
+  }
+
+  async removeGroupsFromUser(filter, update, db) {
+    return handlers.removeGroupsFromUser(filter, update, db);
   }
 };

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -7,7 +7,7 @@ const buildSingleDocumentLink = require('../../../lib/modules/buildSingleDocumen
 const { ObjectId } = require('mongodb');
 const ValidationError = require('../../../lib/errors/ValidationError');
 const { getDocumentLockServiceOptions } = require('./modules/serviceOptions');
-
+const { getUserService } = require('./services/userService');
 const getEmitPayload = (req, additionalProps) => {
   return Object.assign(
     {
@@ -228,7 +228,7 @@ module.exports.postDocUser = function (req, res) {
 
 module.exports.delDocUser = function (req, res) {
   documentService
-    .removeUserFromDocument(req.resource, req.filter, req.params.user, req.db)
+    .removeUserFromDocument(req.resource, req.filter, req.params.user, req.db, getUserService(req.options, req.service.server))
     .then(users => userService.fetchUsers(users, req.options, req.service.server))
     .then(result => helpers.json(res, result))
     .then(() => req.service.emit('document/users/removed', getEmitPayload(req, { removedUserId: req.params.user })))

--- a/services/docs/lib/services/userService.js
+++ b/services/docs/lib/services/userService.js
@@ -1,0 +1,5 @@
+module.exports.getUserService = (options, server) => {
+  const auth = server.services.get('auth');
+
+  return auth;
+};

--- a/services/versioned-docs/lib/handlers.js
+++ b/services/versioned-docs/lib/handlers.js
@@ -4,6 +4,7 @@ const documentService = require('./services/document');
 const userService = require('./services/user');
 const buildLink = require('../../../lib/modules/buildLink');
 const createError = require('http-errors');
+const { getUserService } = require('./services/userService');
 
 const getEmitPayload = (req, additionalProps) => {
   return Object.assign(
@@ -127,7 +128,7 @@ module.exports.delDoc = async (req, res, next) => {
   return req.service.emit('versionedDocument/deleted', getEmitPayload(req));
 };
 
-module.exports.getResources = function(req, res, next) {
+module.exports.getResources = function (req, res, next) {
   return helpers.json(res, resourceService.getResources(req.options));
 };
 
@@ -149,7 +150,14 @@ module.exports.postDocUser = async (req, res, next) => {
 };
 
 module.exports.delDocUser = async (req, res, next) => {
-  const usersId = await documentService.removeUserFromDocument(req.resource, req.filter, req.params.user, req.db);
+  const usersId = await documentService.removeUserFromDocument(
+    req.resource,
+    req.filter,
+    req.params.user,
+    req.db,
+    getUserService(req.options, req.service.server)
+  );
+
   if (!usersId) return next(createError(404, 'Document not found'));
 
   const users = await userService.fetchUsers(usersId, req.options, req.service.server);

--- a/services/versioned-docs/lib/services/userService.js
+++ b/services/versioned-docs/lib/services/userService.js
@@ -1,0 +1,5 @@
+module.exports.getUserService = (options, server) => {
+  const auth = server.services.get('auth');
+
+  return auth;
+};

--- a/test/auth/auth.js
+++ b/test/auth/auth.js
@@ -25,7 +25,6 @@ const glenda = {
   password: 'signup!'
 };
 
-
 const bob = {
   displayName: 'Bobby baton',
   email: 'b.baton@donuts.fr',

--- a/test/config/test.js
+++ b/test/config/test.js
@@ -86,6 +86,10 @@ module.exports = {
       title: 'Versioned docs',
       description: 'Versioned docs db structure',
       options: {
+        userService: async server => {
+          const authService = await server.services.get('auth');
+          return authService;
+        },
         usersFetcher: async (usersId, server) => {
           const users = await server.services.get('auth').fetchUsers(usersId.map(u => u.userId));
           return users.map(u => {

--- a/test/config/test.js
+++ b/test/config/test.js
@@ -86,9 +86,8 @@ module.exports = {
       title: 'Versioned docs',
       description: 'Versioned docs db structure',
       options: {
-        userService: async server => {
-          const authService = await server.services.get('auth');
-          return authService;
+        userService: server => {
+          return server.services.get('auth');
         },
         usersFetcher: async (usersId, server) => {
           const users = await server.services.get('auth').fetchUsers(usersId.map(u => u.userId));

--- a/test/docs/config/options/docs.js
+++ b/test/docs/config/options/docs.js
@@ -3,6 +3,9 @@ module.exports = {
     new Promise((resolve, reject) => {
       resolve(users.map(user => Object.assign({}, user, { displayName: `External user ${user.userId}` })));
     }),
+  userService: server => {
+    return server.services.get('auth');
+  },
   roles: {
     admin: {
       label: 'Administrateur',

--- a/test/docs/events.js
+++ b/test/docs/events.js
@@ -20,7 +20,8 @@ format.extend(String.prototype);
 chai.use(chaiHttp);
 
 const services = {
-  Docs: require('../../services/docs/lib')
+  Docs: require('../../services/docs/lib'),
+  Auth: require('../../services/auth/lib')
 };
 
 const me = { _id: 'me' };
@@ -37,6 +38,7 @@ describe('Events', () => {
         client.close();
         campsi = new CampsiServer(config.campsi);
         campsi.mount('docs', new services.Docs(config.services.docs));
+        campsi.mount('auth', new services.Auth(config.services.auth));
         campsi.app.use((req, res, next) => {
           req.user = me;
           next();

--- a/test/docs/owner.js
+++ b/test/docs/owner.js
@@ -22,7 +22,8 @@ format.extend(String.prototype);
 chai.use(chaiHttp);
 
 const services = {
-  Docs: require('../../services/docs/lib')
+  Docs: require('../../services/docs/lib'),
+  Auth: require('../../services/auth/lib')
 };
 
 const me = {
@@ -67,6 +68,7 @@ describe('Owner', () => {
         client.close();
         campsi = new CampsiServer(config.campsi);
         campsi.mount('docs', new services.Docs(config.services.docs));
+        campsi.mount('auth', new services.Auth(config.services.auth));
         campsi.app.use((req, res, next) => {
           req.user = me;
           next();

--- a/test/versioned-docs/versioned-docs.js
+++ b/test/versioned-docs/versioned-docs.js
@@ -12,7 +12,8 @@ chai.use(chaiHttp);
 chai.should();
 
 const services = {
-  VersionedDocs: require('../../services/versioned-docs/lib')
+  VersionedDocs: require('../../services/versioned-docs/lib'),
+  Auth: require('../../services/auth/lib')
 };
 
 let current = {
@@ -35,10 +36,7 @@ describe('VersionedDocs API', () => {
 
   describe('/POST documents', () => {
     it('it should return a newly created document', async () => {
-      const res = await chai
-        .request(context.campsi.app)
-        .post('/versioneddocs/contracts')
-        .send(current);
+      const res = await chai.request(context.campsi.app).post('/versioneddocs/contracts').send(current);
       res.should.have.status(200);
       res.should.be.json;
       res.body.should.be.a('object');
@@ -52,10 +50,7 @@ describe('VersionedDocs API', () => {
   describe('/POST invalid document', () => {
     it('it should return a validation error', async () => {
       const { content, ...incompleteDocPayload } = current;
-      const res = await chai
-        .request(context.campsi.app)
-        .post('/versioneddocs/contracts')
-        .send(incompleteDocPayload);
+      const res = await chai.request(context.campsi.app).post('/versioneddocs/contracts').send(incompleteDocPayload);
       res.should.have.status(500);
       res.should.be.json;
       res.body.should.be.a('object');


### PR DESCRIPTION
Goal of the PR was to remove direct references to the users collection in the docs and versioned docs services.

I created a sort of dependency injection by looking for a definition of the auth service in the docs and versioned docs config files. The definition points to the auth service which is expected to expose a removeUsersFromGroup which includes the logic that was being used in docs and versioned docs to remove a user from a group, however instead of implementing the functionality in docs and versioned docs we are now relying on the auth service to implement it for us.

If the service is not defined, the route delDocUser will still complete ok however a message will be logged by the debugger warning us that the method to remove the user from the group is not available.