### PR TITLE
Dev 2125 feat/add password regex option

### DIFF
--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -111,6 +111,10 @@ module.exports.createRandomToken = function (username, salt) {
 
 module.exports.signup = function (req, res) {
   const salt = req.authProvider.options.salt;
+  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex);
+  if(!passwordRegex.test(req.body.password)){
+    return helpers.error(res, new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`));
+  }
   const users = req.db.collection(getUsersCollectionName());
   const missingParameters = ['password', 'displayName', 'username'].filter(prop => {
     return typeof req.body[prop] === 'undefined' || req.body.prop === '';
@@ -118,6 +122,7 @@ module.exports.signup = function (req, res) {
   if (missingParameters.length > 0) {
     return helpers.error(res, new Error(`missing parameters : ${missingParameters.join(', ')}`));
   }
+  req.body.password
   const insertUser = function (user) {
     return new Promise((resolve, reject) => {
       users
@@ -165,6 +170,11 @@ module.exports.signup = function (req, res) {
     });
   };
 
+  if(req.body.email){
+    if(!passwordRegex.test("^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$")){
+      return helpers.error(res, new Error(`Invalid email`));
+    }
+  }
   const email = String(req.body.email || req.body.username).toLowerCase();
   module.exports
     .encryptPassword(req.body.password)
@@ -328,6 +338,10 @@ module.exports.createResetPasswordToken = function (req, res) {
  */
 module.exports.resetPassword = function (req, res) {
   const missingParams = getMissingParameters(req.body, ['password', 'token']);
+  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex);
+  if(!passwordRegex.test(req.body.password)){
+    return helpers.error(res, new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`));
+  }
   if (missingParams.length > 0) {
     return helpers.error(res, new Error(`missing parameter(s) : ${missingParams.join(', ')}`));
   }
@@ -380,6 +394,10 @@ module.exports.resetPassword = function (req, res) {
  */
 module.exports.updatePassword = function (req, res) {
   const missingParams = getMissingParameters(req.body, ['new', 'confirm']);
+  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex);
+  if(!passwordRegex.test(req.body.password)){
+    return helpers.error(res, new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`));
+  }
   if (missingParams.length > 0) {
     return helpers.error(res, new Error(`missing parameter(s) : ${missingParams.join(', ')}`));
   }

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -400,7 +400,7 @@ module.exports.resetPassword = function (req, res) {
 module.exports.updatePassword = function (req, res) {
   const missingParams = getMissingParameters(req.body, ['new', 'confirm']);
   const passwordRegex = new RegExp(req.authProvider.options.passwordRegex);
-  if (!passwordRegex.test(req.body.password)) {
+  if (!passwordRegex.test(req.body.new)) {
     return helpers.error(
       res,
       new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`)

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -111,11 +111,11 @@ module.exports.createRandomToken = function (username, salt) {
 
 module.exports.signup = function (req, res) {
   const salt = req.authProvider.options.salt;
-  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex);
+  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex ?? '/.*/');
   if (!passwordRegex.test(req.body.password)) {
     return helpers.error(
       res,
-      new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`)
+      new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex}`)
     );
   }
   const users = req.db.collection(getUsersCollectionName());
@@ -340,11 +340,11 @@ module.exports.createResetPasswordToken = function (req, res) {
  */
 module.exports.resetPassword = function (req, res) {
   const missingParams = getMissingParameters(req.body, ['password', 'token']);
-  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex);
+  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex ?? '/.*/');
   if (!passwordRegex.test(req.body.password)) {
     return helpers.error(
       res,
-      new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`)
+      new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex}`)
     );
   }
   if (missingParams.length > 0) {
@@ -399,11 +399,11 @@ module.exports.resetPassword = function (req, res) {
  */
 module.exports.updatePassword = function (req, res) {
   const missingParams = getMissingParameters(req.body, ['new', 'confirm']);
-  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex);
+  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex ?? '/.*/');
   if (!passwordRegex.test(req.body.new)) {
     return helpers.error(
       res,
-      new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`)
+      new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex}`)
     );
   }
   if (missingParams.length > 0) {

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -173,7 +173,7 @@ module.exports.signup = function (req, res) {
   };
 
   if (req.body.email) {
-    if (!passwordRegex.test('^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$')) {
+    if (!/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(req.body.email)) {
       return helpers.error(res, new Error('Invalid email'));
     }
   }

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -112,8 +112,11 @@ module.exports.createRandomToken = function (username, salt) {
 module.exports.signup = function (req, res) {
   const salt = req.authProvider.options.salt;
   const passwordRegex = new RegExp(req.authProvider.options.passwordRegex);
-  if(!passwordRegex.test(req.body.password)){
-    return helpers.error(res, new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`));
+  if (!passwordRegex.test(req.body.password)) {
+    return helpers.error(
+      res,
+      new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`)
+    );
   }
   const users = req.db.collection(getUsersCollectionName());
   const missingParameters = ['password', 'displayName', 'username'].filter(prop => {
@@ -122,7 +125,6 @@ module.exports.signup = function (req, res) {
   if (missingParameters.length > 0) {
     return helpers.error(res, new Error(`missing parameters : ${missingParameters.join(', ')}`));
   }
-  req.body.password
   const insertUser = function (user) {
     return new Promise((resolve, reject) => {
       users
@@ -170,9 +172,9 @@ module.exports.signup = function (req, res) {
     });
   };
 
-  if(req.body.email){
-    if(!passwordRegex.test("^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$")){
-      return helpers.error(res, new Error(`Invalid email`));
+  if (req.body.email) {
+    if (!passwordRegex.test('^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$')) {
+      return helpers.error(res, new Error('Invalid email'));
     }
   }
   const email = String(req.body.email || req.body.username).toLowerCase();
@@ -339,8 +341,11 @@ module.exports.createResetPasswordToken = function (req, res) {
 module.exports.resetPassword = function (req, res) {
   const missingParams = getMissingParameters(req.body, ['password', 'token']);
   const passwordRegex = new RegExp(req.authProvider.options.passwordRegex);
-  if(!passwordRegex.test(req.body.password)){
-    return helpers.error(res, new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`));
+  if (!passwordRegex.test(req.body.password)) {
+    return helpers.error(
+      res,
+      new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`)
+    );
   }
   if (missingParams.length > 0) {
     return helpers.error(res, new Error(`missing parameter(s) : ${missingParams.join(', ')}`));
@@ -395,8 +400,11 @@ module.exports.resetPassword = function (req, res) {
 module.exports.updatePassword = function (req, res) {
   const missingParams = getMissingParameters(req.body, ['new', 'confirm']);
   const passwordRegex = new RegExp(req.authProvider.options.passwordRegex);
-  if(!passwordRegex.test(req.body.password)){
-    return helpers.error(res, new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`));
+  if (!passwordRegex.test(req.body.password)) {
+    return helpers.error(
+      res,
+      new Error(`Invalid password, please respect this regex : ${req.authProvider.options.passwordRegex ?? '/.*/'}`)
+    );
   }
   if (missingParams.length > 0) {
     return helpers.error(res, new Error(`missing parameter(s) : ${missingParams.join(', ')}`));

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -111,7 +111,7 @@ module.exports.createRandomToken = function (username, salt) {
 
 module.exports.signup = function (req, res) {
   const salt = req.authProvider.options.salt;
-  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex ?? '/.*/');
+  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex ?? '.*');
   if (!passwordRegex.test(req.body.password)) {
     return helpers.error(
       res,
@@ -340,7 +340,7 @@ module.exports.createResetPasswordToken = function (req, res) {
  */
 module.exports.resetPassword = function (req, res) {
   const missingParams = getMissingParameters(req.body, ['password', 'token']);
-  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex ?? '/.*/');
+  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex ?? '.*');
   if (!passwordRegex.test(req.body.password)) {
     return helpers.error(
       res,
@@ -399,7 +399,7 @@ module.exports.resetPassword = function (req, res) {
  */
 module.exports.updatePassword = function (req, res) {
   const missingParams = getMissingParameters(req.body, ['new', 'confirm']);
-  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex ?? '/.*/');
+  const passwordRegex = new RegExp(req.authProvider.options.passwordRegex ?? '.*');
   if (!passwordRegex.test(req.body.new)) {
     return helpers.error(
       res,

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -81,7 +81,7 @@ module.exports.getLocks = async function (state, filter, user, editLock, db) {
 };
 
 const getDocumentLock = async function (state, filter, lockCollection) {
-  if (!filter._id) {
+  if (!filter?._id) {
     return undefined;
   }
 

--- a/test/auth/auth-fetch-users.js
+++ b/test/auth/auth-fetch-users.js
@@ -20,6 +20,13 @@ const glenda = {
   password: 'signup!'
 };
 
+const badGlenda = {
+  displayName: 'Glenda Bennett',
+  email: 'glenda@agilitation',
+  username: 'badGlenda',
+  password: 'signup!'
+};
+
 const services = {
   Auth: require('../../services/auth/lib'),
   Trace: require('campsi-service-trace'),
@@ -35,7 +42,7 @@ function createUser(campsi, user) {
       .send(user)
       .end((err, res) => {
         if (err) return reject(err);
-        resolve(res.body.token);
+        resolve(res);
       });
   });
 }
@@ -46,7 +53,8 @@ describe('User Fetching', () => {
   afterEach(done => context.server.close(done));
   describe('AuthService.fetchUsers', () => {
     it('it should return an array of user objects', done => {
-      createUser(context.campsi, glenda).then(bearerToken => {
+      createUser(context.campsi, glenda).then(res => {
+        const bearerToken = res.body.token;
         chai
           .request(context.campsi.app)
           .get('/auth/me')
@@ -69,6 +77,13 @@ describe('User Fetching', () => {
                 done();
               });
           });
+      });
+    });
+    it('create bad user', done => {
+      createUser(context.campsi, badGlenda).then(res => {
+        console.log(res.status);
+        res.should.have.status(400);
+        done();
       });
     });
   });

--- a/test/auth/auth-fetch-users.js
+++ b/test/auth/auth-fetch-users.js
@@ -81,7 +81,6 @@ describe('User Fetching', () => {
     });
     it('create bad user', done => {
       createUser(context.campsi, badGlenda).then(res => {
-        console.log(res.status);
         res.should.have.status(400);
         done();
       });

--- a/test/auth/auth-local-passwordRegex.js
+++ b/test/auth/auth-local-passwordRegex.js
@@ -25,6 +25,13 @@ const glenda = {
   password: firstPassword
 };
 
+const glenda2 = {
+  displayName: 'Glenda Bennett',
+  email: 'glenda2@agilitation.fr',
+  username: 'glenda2',
+  password: firstPassword
+};
+
 const services = {
   Auth: require('../../services/auth/lib'),
   Trace: require('campsi-service-trace'),
@@ -43,7 +50,6 @@ const resetUserPassword = (chai, campsi, username, passwordResetToken, newPasswo
     token: passwordResetToken,
     password: newPassword
   });
-
 describe('Auth Local Password Regex', () => {
   const context = {};
   beforeEach(setupBeforeEach(config, services, context));
@@ -54,6 +60,7 @@ describe('Auth Local Password Regex', () => {
   describe('/GET local/reset password ', () => {
     it('it should validate the user', done => {
       const campsi = context.campsi;
+      campsi.services.get('auth').options.providers.local.options.passwordRegex = /^((?!ilyes).)*$/s;
       campsi.on('auth/local/passwordResetTokenCreated', ({ user }) => {
         const passwordResetToken = user.identities.local.passwordResetToken.value;
         resetUserPassword(chai, campsi, glenda.username, passwordResetToken, 'ilyes').end((err, res) => {
@@ -126,7 +133,7 @@ describe('Auth Local Password Regex', () => {
         .request(campsi.app)
         .post('/auth/local/signup')
         .set('content-type', 'application/json')
-        .send(Object.assign({}, glenda, { password: firstPassword }))
+        .send(Object.assign({}, glenda2, { password: firstPassword }))
         // eslint-disable-next-line n/handle-callback-err
         .end((err, res) => {
           const token = res.body.token;
@@ -159,6 +166,7 @@ describe('Auth Local Password Regex', () => {
                   res.should.have.status(200);
                   res.should.be.json;
                   res.body.should.be.a('object');
+                  delete campsi.services.get('auth').options.providers.local.options.passwordRegex;
                 });
               done();
             });

--- a/test/auth/auth-local-passwordRegex.js
+++ b/test/auth/auth-local-passwordRegex.js
@@ -165,7 +165,6 @@ describe('Auth Local Password Regex', () => {
               done();
             });
         });
-      delete campsi.services.get('auth').options.providers.local.options.passwordRegex;
     });
   });
 });

--- a/test/auth/auth-local-passwordRegex.js
+++ b/test/auth/auth-local-passwordRegex.js
@@ -1,0 +1,171 @@
+/* eslint-disable no-unused-expressions */
+process.env.NODE_CONFIG_DIR = './test/config';
+process.env.NODE_ENV = 'test';
+
+// Require the dev-dependencies
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const format = require('string-format');
+const createUser = require('../helpers/createUser');
+const setupBeforeEach = require('../helpers/setupBeforeEach');
+const config = require('config');
+const debug = require('debug')('campsi:test');
+
+format.extend(String.prototype);
+chai.use(chaiHttp);
+chai.should();
+
+const firstPassword = 'Axeptio1234!';
+const newPassword = 'Agilitation1234!';
+
+const glenda = {
+  displayName: 'Glenda Bennett',
+  email: 'glenda@agilitation.fr',
+  username: 'glenda',
+  password: firstPassword
+};
+
+const services = {
+  Auth: require('../../services/auth/lib'),
+  Trace: require('campsi-service-trace'),
+  Assets: require('../../services/assets/lib')
+};
+
+const signin = (chai, campsi, username, password) =>
+  chai.request(campsi.app).post('/auth/local/signin').send({ username, password });
+
+const createResetPasswordToken = (chai, campsi, email) =>
+  chai.request(campsi.app).post('/auth/local/reset-password-token').send({ email });
+
+const resetUserPassword = (chai, campsi, username, passwordResetToken, newPassword) =>
+  chai.request(campsi.app).post('/auth/local/reset-password').send({
+    username,
+    token: passwordResetToken,
+    password: newPassword
+  });
+
+describe('Auth Local Password Regex', () => {
+  const context = {};
+  beforeEach(setupBeforeEach(config, services, context));
+  afterEach(done => context.server.close(done));
+  /*
+   * Test the /GET local/validate route
+   */
+  describe('/GET local/reset password ', () => {
+    it('it should validate the user', done => {
+      const campsi = context.campsi;
+      campsi.on('auth/local/passwordResetTokenCreated', ({ user }) => {
+        console.log(user);
+        const passwordResetToken = user.identities.local.passwordResetToken.value;
+        resetUserPassword(chai, campsi, glenda.username, passwordResetToken, 'ilyes').end((err, res) => {
+          if (err) debug(`received an error from chai: ${err.message}`);
+          res.should.have.status(400);
+        });
+        resetUserPassword(chai, campsi, glenda.username, passwordResetToken, newPassword).end((err, res) => {
+          if (err) debug(`received an error from chai: ${err.message}`);
+          res.should.have.status(200);
+
+          signin(chai, campsi, glenda.username, firstPassword).end((err, res) => {
+            if (err) debug(`received an error from chai: ${err.message}`);
+            res.should.have.status(400);
+            res.should.be.json;
+            res.body.should.not.have.property('token');
+
+            signin(chai, campsi, glenda.username, newPassword).end((err, res) => {
+              if (err) debug(`received an error from chai: ${err.message}`);
+              res.should.have.status(200);
+              res.should.be.json;
+              res.body.should.have.property('token');
+              done();
+            });
+          });
+        });
+      });
+
+      createUser(chai, campsi, glenda).then(() => {
+        createResetPasswordToken(chai, campsi, glenda.email).end((err, res) => {
+          if (err) debug(`received an error from chai: ${err.message}`);
+          res.should.have.status(200);
+          res.should.be.json;
+          res.body.should.be.a('object');
+        });
+      });
+    });
+  });
+  describe('/POST local/signup', () => {
+    it('it should do something', done => {
+      const campsi = context.campsi;
+      chai
+        .request(campsi.app)
+        .post('/auth/local/signup')
+        .set('content-type', 'application/json')
+        .send(Object.assign({}, glenda, { password: 'ilyes' }))
+        .end((err, res) => {
+          if (err) debug(`received an error from chai: ${err.message}`);
+          res.should.have.status(400);
+          res.should.be.json;
+          res.body.should.be.a('object');
+          chai
+            .request(campsi.app)
+            .post('/auth/local/signup')
+            .set('content-type', 'application/json')
+            .send(Object.assign({}, glenda, { password: firstPassword }))
+            .end((err, res) => {
+              if (err) debug(`received an error from chai: ${err.message}`);
+              res.should.have.status(200);
+              res.should.be.json;
+              res.body.should.be.a('object');
+            });
+          done();
+        });
+    });
+  });
+  describe('/PUT local/update-password', () => {
+    it('it should return an error', done => {
+      const campsi = context.campsi;
+      chai
+        .request(campsi.app)
+        .post('/auth/local/signup')
+        .set('content-type', 'application/json')
+        .send(Object.assign({}, glenda, { password: firstPassword }))
+        // eslint-disable-next-line n/handle-callback-err
+        .end((err, res) => {
+          const token = res.body.token;
+          chai
+            .request(campsi.app)
+            .put('/auth/local/update-password')
+            .set('content-type', 'application/json')
+            .set('Authorization', 'Bearer ' + token)
+            .send({
+              new: 'ilyes',
+              confirm: 'ilyes'
+            })
+            .end((err, res) => {
+              if (err) debug(`received an error from chai: ${err.message}`);
+              res.should.have.status(400);
+              res.should.be.json;
+              res.body.should.be.a('object');
+              res.body.should.have.property('message');
+              chai
+                .request(campsi.app)
+                .put('/auth/local/update-password')
+                .set('content-type', 'application/json')
+                .set('Authorization', 'Bearer ' + token)
+                .send({
+                  new: firstPassword,
+                  confirm: firstPassword
+                })
+                .end((err, res) => {
+                  if (err) debug(`received an error from chai: ${err.message}`);
+                  res.should.have.status(200);
+                  res.should.be.json;
+                  res.body.should.be.a('object');
+                  res.body.should.have.property('message');
+                });
+              done();
+            });
+        });
+      delete campsi.services.get('auth').options.providers.local.options.passwordRegex;
+    });
+  });
+});

--- a/test/auth/auth-local-passwordRegex.js
+++ b/test/auth/auth-local-passwordRegex.js
@@ -159,7 +159,6 @@ describe('Auth Local Password Regex', () => {
                   res.should.have.status(200);
                   res.should.be.json;
                   res.body.should.be.a('object');
-                  res.body.should.have.property('message');
                 });
               done();
             });

--- a/test/auth/auth-local-passwordRegex.js
+++ b/test/auth/auth-local-passwordRegex.js
@@ -55,7 +55,6 @@ describe('Auth Local Password Regex', () => {
     it('it should validate the user', done => {
       const campsi = context.campsi;
       campsi.on('auth/local/passwordResetTokenCreated', ({ user }) => {
-        console.log(user);
         const passwordResetToken = user.identities.local.passwordResetToken.value;
         resetUserPassword(chai, campsi, glenda.username, passwordResetToken, 'ilyes').end((err, res) => {
           if (err) debug(`received an error from chai: ${err.message}`);

--- a/test/config/test.js
+++ b/test/config/test.js
@@ -72,8 +72,7 @@ module.exports = {
           local: require('../../services/auth/lib/providers/local')({
             baseUrl: host + '/auth',
             salt: 'CNDygyeFC6536964425994',
-            resetPasswordTokenExpiration: 10,
-            passwordRegex: /^((?!ilyes).)*$/s
+            resetPasswordTokenExpiration: 10
           }),
           github: require('../../services/auth/lib/providers/github')({
             baseUrl: host + '/auth',

--- a/test/config/test.js
+++ b/test/config/test.js
@@ -72,7 +72,8 @@ module.exports = {
           local: require('../../services/auth/lib/providers/local')({
             baseUrl: host + '/auth',
             salt: 'CNDygyeFC6536964425994',
-            resetPasswordTokenExpiration: 10
+            resetPasswordTokenExpiration: 10,
+            passwordRegex: /^((?!ilyes).)*$/s
           }),
           github: require('../../services/auth/lib/providers/github')({
             baseUrl: host + '/auth',


### PR DESCRIPTION
In this feat, we add a new password regexp option in the auth service.

The routes concerned are : 
- signup
- reset-password
- updatePassword

btw, a verification of the email field has been added

Tested locally with caas-api & caas-styleguide

Doc updated