### PR TITLE
add a docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,74 +189,72 @@ npm run test
 
 #### Root
 
-| Property      | Type                 |  Description
-|:------------- |:-------------------  |:--------------------------------------
-| `name`        | `String`             | unique identifier of your api
-| `title`       | `String`             | title of the API
-| `description` | `String`             | markdown description
-| `roles`       | `<Role>`             | roles hashmap
-| `types`       | `<ResourceType>`     | resource types hashmap
-| `resources`   | `<Resource>`         | resources hasmap
+| Property      | Type             | Description                   |
+|:--------------|:-----------------|:------------------------------|
+| `name`        | `String`         | unique identifier of your api |
+| `title`       | `String`         | title of the API              |
+| `description` | `String`         | markdown description          |
+| `roles`       | `<Role>`         | roles hashmap                 |
+| `types`       | `<ResourceType>` | resource types hashmap        |
+| `resources`   | `<Resource>`     | resources hasmap              |
 
 #### Role
 
-| Property    | Type      | Description
-|:----------- |:--------  |:------------------------------
-| `label`     | `String`  | unique identifier of your api
-| `auth`      | `Boolean` | title of the API
-| `admin`     | `Boolean` | markdown descripition
+| Property | Type      | Description                   |
+|:---------|:----------|:------------------------------|
+| `label`  | `String`  | unique identifier of your api |
+| `auth`   | `Boolean` | title of the API              |
+| `admin`  | `Boolean` | markdown descripition         |
 
 #### ResourceType
 
-| Property          | Type                      |  Description
-|:----------------- |:------------------------  |:--------------------------------------
-| `defaultState`    | `String`                  | name of the state any request will default to
-| `states`          | `<State>`                 | hashmap of the states
-| `permissions`     | `<Role, <State, Method>>` | Allowed HTTP methods by role and by state
+| Property       | Type                      | Description                                   |
+|:---------------|:--------------------------|:----------------------------------------------|
+| `defaultState` | `String`                  | name of the state any request will default to |
+| `states`       | `<State>`                 | hashmap of the states                         |
+| `permissions`  | `<Role, <State, Method>>` | Allowed HTTP methods by role and by state     |
 
 #### State
 
-| Property       | type         |  Description
-|:-------------- |:-----------  |:--------------------------------------
-| `name`         | `String`     | name of the state any request will default to
-| `label`        | `String`     | hashmap of the states
-| `validate`     | `Boolean`    | wether the data has to be valid to be saved or not
+| Property   | type      | Description                                        |
+|:-----------|:----------|:---------------------------------------------------|
+| `name`     | `String`  | name of the state any request will default to      |
+| `label`    | `String`  | hashmap of the states                              |
+| `validate` | `Boolean` | wether the data has to be valid to be saved or not |
 
 #### Resource
 
-| Property          | type         |  Description
-|:----------------- |:-----------  |:--------------------------------------
-| `title`           | `String`     | readable title
-| `description`     | `String`     | markdown description
-| `type`            | `String`     | name of the ResourceType
-| `fields`          | `[Object]`   | list of the fields composing the model
-| `hooks`           | `[Hook]`     | list of hooks bound to the resource
-| `rels`            | `<Rel>`      | hashmap of relationships
+| Property      | type       | Description                            |
+|:--------------|:-----------|:---------------------------------------|
+| `title`       | `String`   | readable title                         |
+| `description` | `String`   | markdown description                   |
+| `type`        | `String`   | name of the ResourceType               |
+| `fields`      | `[Object]` | list of the fields composing the model |
+| `hooks`       | `[Hook]`   | list of hooks bound to the resource    |
+| `rels`        | `<Rel>`    | hashmap of relationships               |
 
 #### Rel
 
-| Property          | type         |  Description
-|:----------------- |:-----------  |:--------------------------------------
-| `path`            | `String`     | property path
-| `resource`        | `String`     | name of the resource it points to (self reference is OK)
-| `embed`           | `Boolean`    | resolve relation automatically
-| `fields`          | `[String]`   | list of the fields that gets embedded
-
+| Property   | type       | Description                                              |
+|:-----------|:-----------|:---------------------------------------------------------|
+| `path`     | `String`   | property path                                            |
+| `resource` | `String`   | name of the resource it points to (self reference is OK) |
+| `embed`    | `Boolean`  | resolve relation automatically                           |
+| `fields`   | `[String]` | list of the fields that gets embedded                    |
 
 #### Hook
 
-| Property          | type              |  Description
-|:----------------- |:----------------  |:--------------------------------------
-| `name`            | `String`          | hook identifier
-| `uri`             | `String`          | todo support parameter
-| `method`          | `String`          | one of `POST` `GET` `PUT` `DELETE`
-| `payload`         | `Boolean`         | if true and method is `POST` or `PUT`, send the `data`
-| `on`              | `[String]`        | list of actions
-| `states`          | `[String]`        | list of states
-| `retry`           | `Number`          | number of time the HTTP client tries to reach the endpoint
-| `timeout`         | `Number`          | number of seconds before the HTTP client hangs up
-| `headers`         | `<String,String>` | hashmap of the request headers
-
+| Property  | type              | Description                                                |
+|:----------|:------------------|:-----------------------------------------------------------|
+| `name`    | `String`          | hook identifier                                            |
+| `uri`     | `String`          | todo support parameter                                     |
+| `method`  | `String`          | one of `POST` `GET` `PUT` `DELETE`                         |
+| `payload` | `Boolean`         | if true and method is `POST` or `PUT`, send the `data`     |
+| `on`      | `[String]`        | list of actions                                            |
+| `states`  | `[String]`        | list of states                                             |
+| `retry`   | `Number`          | number of time the HTTP client tries to reach the endpoint |
+| `timeout` | `Number`          | number of seconds before the HTTP client hangs up          |
+| `headers` | `<String,String>` | hashmap of the request headers                             |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ docker compose restart
 Once the containers are running, you can start the server by running:
 
 ```sh
-node run test
+npm run test
 ```
 
 ### Flags

--- a/README.md
+++ b/README.md
@@ -174,9 +174,7 @@ docker compose restart
 Once the containers are running, you can start the server by running:
 
 ```sh
-node auth-index.js
-# or
-npm start
+node run test
 ```
 
 ### Flags

--- a/README.md
+++ b/README.md
@@ -153,6 +153,25 @@ You can configure webhooks that are triggered when an request processed by _camp
 _todo_ distributed architecture example
 
 ## Usage
+First, start Redis and MongoDB containers by running:
+
+```sh
+docker compose up -d
+```
+
+To stop the containers, run:
+
+```sh
+docker compose down
+```
+
+To restart the containers, run:
+
+```sh
+docker compose restart
+```
+
+Once the containers are running, you can start the server by running:
 
 ```sh
 node auth-index.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  redis:
+    image: redis
+    ports:
+      - "6380:6380"
+  mongo:
+    container_name: "campsi-mono-mongodb"
+    image: mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb-data:/data/db/
+volumes:
+  mongodb-data:


### PR DESCRIPTION
In this pr, we add the possibility of being able to use docker to launch campsi-mono locally, avoiding the installation of mongoDB as well as version / architecture conflicts.

- create a docker compose file with mongo 5.0.9 Community

- add the run command in the readme