### PR TITLE
As a developer, I want to check email account uniqueness

### DIFF
--- a/test/auth/auth-local.js
+++ b/test/auth/auth-local.js
@@ -90,6 +90,28 @@ describe('Auth Local API', () => {
           });
       });
     });
+    it('it should return an error, user exists with upper case email', done => {
+      createUser(context.campsi, glenda).then(() => {
+        chai
+          .request(context.campsi.app)
+          .post('/auth/local/signup')
+          .set('content-type', 'application/json')
+          .send({
+            displayName: 'Glenda Bennett 2',
+            email: 'GLENDA@agilitation.fr',
+            username: 'glenda',
+            password: 'signup!'
+          })
+          .end((err, res) => {
+            if (err) debug(`received an error from chai: ${err.message}`);
+            res.should.have.status(400);
+            res.should.be.json;
+            res.body.should.be.a('object');
+            res.body.should.have.property('message');
+            done();
+          });
+      });
+    });
   });
   describe('/POST local/signup [password too long]', () => {
     it('it should do something', done => {


### PR DESCRIPTION
It was reported that on signup it was possible to create an account with an existing email if the case was different. 
I added a test case to test this hypothesis and tested manually from the front end, it does not appear possible to do this anymore.

The CODE in the PR is an additional test to signup with a an existing user email in a different case (it is supposed to fail)