### PR TITLE
fix: paging systems with agregation cursor

### DIFF
--- a/lib/modules/paginateCursor.js
+++ b/lib/modules/paginateCursor.js
@@ -51,6 +51,7 @@ module.exports = function paginateCursor(cursor, options) {
         .then(documents => {
           const count = documents.length;
           cursor.rewind();
+          cursor.skip(skip).limit(limit);
           return resolve(preparePagination(count, skip, limit, page, perPage));
         })
         .catch(error => {


### PR DESCRIPTION
- [x] Tested locally
- [x] Tests have been green
- [x] Linter is ok

In the `paginateCursor()` function, there is a treatment for classic cursors and cursors resulting from an aggregation.
And unfortunately there is an oversight in the application of the pagination on the cursors resulting from an aggregation.
So I add it in this fix