### PR TITLE
fix: allow + in email address

### DIFF
--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -95,7 +95,7 @@ module.exports = class StripeBillingService extends CampsiService {
         stripe.customers.update(req.params.id, bodyToCustomer(req.body, 'default_source'), defaultHandler(res));
       }
       catch(err) {
-        res.status(400).json(ex);
+        res.status(400).json(err);
       }
     });
 
@@ -364,7 +364,7 @@ module.exports = class StripeBillingService extends CampsiService {
   };
 
   checkEmailValidity (email) {
-    if (!/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(email)) {
+    if (!/^\w+([.-/+]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(email)) {
       throw 'Invalid Email';
     }
   };

--- a/test/stripe-billing/test.js
+++ b/test/stripe-billing/test.js
@@ -21,9 +21,6 @@ describe('Stripe Billing Service', () => {
     context.server.close(done);
   });
 
-  /**
-   * Test the journal creation
-   */
   describe('direct service method calls', () => {
     it('should reject the email address', async () => {
       let emailOK;
@@ -94,6 +91,22 @@ describe('Stripe Billing Service', () => {
 
       const billingService = context.campsi.services.get('billing');
       const goodEmail = 'jlotery@hotmail.com';
+
+      try {
+        await billingService.checkEmailValidity(goodEmail);
+        emailOK = true;
+      } catch (ex) {
+        emailOK = false;
+      }
+
+      emailOK.should.be.true;
+    });
+
+    it('should accept an email address with a + ', async () => {
+      let emailOK;
+
+      const billingService = context.campsi.services.get('billing');
+      const goodEmail = 'bob+munch@hotmail.com';
 
       try {
         await billingService.checkEmailValidity(goodEmail);


### PR DESCRIPTION
self explanatory - allow use of the plus symbol (+) in the first part of an email address before the '@'