### PR TITLE
feat: add idempotency key to some stripe API calls (DEV-2556)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8053,7 +8053,7 @@
         "mqtt-emitter": "^1.2.4",
         "passport-github2": "^0.1.10",
         "path": "^0.12.7",
-        "pino-datadog-transport": "*",
+        "pino-datadog-transport": "^1.2.2",
         "pino-http": "^7.0.0",
         "prettier": "^2.7.1",
         "request": "^2.88.2",


### PR DESCRIPTION
title self-explanatory

To avoid creating a stripe resource multiple time (in case of retry or anything like that), we will use an idempotency key on some POST API calls. This key is a hash built with stripe params, stripe method, and the current timestamp in seconds, to avoid recreating this resource within the same second. 
Don't hesitate if you think a second is not enough