### PR TITLE
Jameslotery/dev 2623

### DIFF
--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -46,31 +46,128 @@ module.exports = class AuthService extends CampsiService {
       req.authProvider = providers[id];
       return !req.authProvider ? helpers.notFound(res) : next();
     });
-    router.get('/users', handlers.getUsers);
-    router.get('/users/:userId/extract_personal_data', handlers.extractUserPersonalData);
-    router.get('/users/:userId/access_token', handlers.getAccessTokenForUser);
-    router.get('/providers', handlers.getProviders);
-    router.get('/me', handlers.me);
-    router.put('/me', handlers.updateMe);
-    router.patch('/me', handlers.patchMe);
-    router.post('/me/groups/:groups', handlers.addGroupsToUser);
-    router.get('/anonymous', handlers.createAnonymousUser);
-    router.get('/logout', handlers.logout);
-    router.post('/invitations', handlers.inviteUser);
-    router.post('/invitations/:invitationToken', handlers.acceptInvitation);
-    router.put('/tokens', handlers.tokenMaintenance);
+    router.get(
+      // #swagger.ignore = true,
+      '/users',
+      handlers.getUsers
+    );
+    router.get(
+      // #swagger.ignore = true,
+      '/users/:userId/extract_personal_data',
+      handlers.extractUserPersonalData
+    );
+    router.get(
+      // #swagger.ignore = true,
+      '/users/:userId/access_token',
+      handlers.getAccessTokenForUser
+    );
+    router.get(
+      // #swagger.ignore = true,
+      '/providers',
+      handlers.getProviders
+    );
+    router.get(
+      // #swagger.ignore = true,
+      '/me',
+      handlers.me
+    );
+    router.put(
+      // #swagger.ignore = true,
+      '/me',
+      handlers.updateMe
+    );
+    router.patch(
+      // #swagger.ignore = true,
+      '/me',
+      handlers.patchMe
+    );
+    router.post(
+      // #swagger.ignore = true,
+      '/me/groups/:groups',
+      handlers.addGroupsToUser
+    );
+    router.get(
+      // #swagger.ignore = true,
+      '/anonymous',
+      handlers.createAnonymousUser
+    );
+    router.get(
+      // #swagger.tags = ['Auth service'],
+      '/logout',
+      handlers.logout
+    );
+    router.post(
+      // #swagger.tags = ['Auth service'],
+      '/invitations',
+      handlers.inviteUser
+    );
+    router.post(
+      // #swagger.tags = ['Auth service'],
+      '/invitations/:invitationToken',
+      handlers.acceptInvitation
+    );
+    router.put(
+      // #swagger.tags = ['Auth service'],
+      // #swagger.ignore = true
+      '/tokens',
+      handlers.tokenMaintenance
+    );
 
     if (providers.local) {
-      router.use('/local', local.middleware(providers.local));
-      router.post('/local/signup', local.signup);
-      router.post('/local/signin', local.signin);
-      router.post('/local/reset-password-token', local.createResetPasswordToken);
-      router.post('/local/reset-password', local.resetPassword);
-      router.get('/local/validate', local.validate);
-      router.put('/local/update-password', local.updatePassword);
+      router.use(
+        // #swagger.ignore = true,
+        '/local',
+        local.middleware(providers.local)
+      );
+      router.post(
+        // #swagger.tags = ['Auth service'],
+        // #swagger.description = 'AUTH_LOCAL_SIGNUP_DESCRIPTION'
+        // #swagger.summary = 'AUTH_LOCAL_SIGNUP_SUMMARY'
+        // #AUTH_LOCAL_SIGNIN_PARAM_REQUEST_BODY
+        // #AUTH_LOCAL_SIGNIN_PARAM_HEADER
+        '/local/signup',
+        local.signup
+      );
+      router.post(
+        // #swagger.tags = ['Auth service'],
+        // #swagger.description = 'AUTH_LOCAL_SIGNIN_DESCRIPTION'
+        // #swagger.summary = 'AUTH_LOCAL_SIGNIN_SUMMARY'
+        // #AUTH_LOCAL_SIGNIN_PARAM_REQUEST_BODY
+        // #AUTH_LOCAL_SIGNIN_PARAM_HEADER
+        '/local/signin',
+        local.signin
+      );
+      router.post(
+        // #swagger.ignore = true
+        '/local/reset-password-token',
+        local.createResetPasswordToken
+      );
+      router.post(
+        // #swagger.ignore = true,
+        '/local/reset-password',
+        local.resetPassword
+      );
+      router.get(
+        // #swagger.ignore = true,
+        '/local/validate',
+        local.validate
+      );
+      router.put(
+        // #swagger.ignore = true,
+        '/local/update-password',
+        local.updatePassword
+      );
     }
-    this.router.get('/:provider', handlers.initAuth);
-    this.router.get('/:provider/callback', handlers.callback);
+    this.router.get(
+      // #swagger.ignore = true,
+      '/:provider',
+      handlers.initAuth
+    );
+    this.router.get(
+      // #swagger.ignore = true,
+      '/:provider/callback',
+      handlers.callback
+    );
   }
 
   getMiddlewares() {

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -87,21 +87,25 @@ module.exports = class AuthService extends CampsiService {
       handlers.addGroupsToUser
     );
     router.get(
+      // #swagger.ignore = true
       // #swagger.ignore = true,
       '/anonymous',
       handlers.createAnonymousUser
     );
     router.get(
+      // #swagger.ignore = true
       // #swagger.tags = ['Auth service'],
       '/logout',
       handlers.logout
     );
     router.post(
+      // #swagger.ignore = true
       // #swagger.tags = ['Auth service'],
       '/invitations',
       handlers.inviteUser
     );
     router.post(
+      // #swagger.ignore = true
       // #swagger.tags = ['Auth service'],
       '/invitations/:invitationToken',
       handlers.acceptInvitation
@@ -120,20 +124,70 @@ module.exports = class AuthService extends CampsiService {
         local.middleware(providers.local)
       );
       router.post(
-        // #swagger.tags = ['Auth service'],
-        // #swagger.description = 'AUTH_LOCAL_SIGNUP_DESCRIPTION'
-        // #swagger.summary = 'AUTH_LOCAL_SIGNUP_SUMMARY'
-        // #AUTH_LOCAL_SIGNIN_PARAM_REQUEST_BODY
-        // #AUTH_LOCAL_SIGNIN_PARAM_HEADER
+        /*
+        #swagger.tags = ['Auth service'],
+        #swagger.description = 'AUTH_LOCAL_SIGNUP_DESCRIPTION'
+        #swagger.summary = 'AUTH_LOCAL_SIGNUP_SUMMARY'
+        #swagger.parameters['X-Requested-With'] = {
+          in: 'header',
+          schema: {
+            type: 'string',
+            '@enum': ['XMLHttpRequest']
+          }
+        }
+        #swagger.requestBody = {
+            required: true,
+            content: {
+                "application/json": {
+                    schema: { $ref: "#/components/schemas/CreateUserRequest" }
+                }
+            }
+        }
+        #swagger.responses[200] = {
+            description: "Token",
+            content: {
+                "application/json": {
+                    schema:{
+                        $ref: "#/components/schemas/TokenResponse"
+                    }
+                }
+            }
+        }
+        */
         '/local/signup',
         local.signup
       );
       router.post(
-        // #swagger.tags = ['Auth service'],
-        // #swagger.description = 'AUTH_LOCAL_SIGNIN_DESCRIPTION'
-        // #swagger.summary = 'AUTH_LOCAL_SIGNIN_SUMMARY'
-        // #AUTH_LOCAL_SIGNIN_PARAM_REQUEST_BODY
-        // #AUTH_LOCAL_SIGNIN_PARAM_HEADER
+        /*
+        #swagger.tags = ['Auth service'],
+        #swagger.description = 'AUTH_LOCAL_SIGNIN_DESCRIPTION'
+        #swagger.summary = 'AUTH_LOCAL_SIGNIN_SUMMARY'
+        #swagger.parameters['X-Requested-With'] = {
+          in: 'header',
+          schema: {
+            type: 'string',
+            '@enum': ['XMLHttpRequest']
+          }
+        }
+        #swagger.requestBody = {
+            required: true,
+            content: {
+                "application/json": {
+                    schema: { $ref: "#/components/schemas/CredentialRequest" }
+                }
+            }
+        }
+        #swagger.responses[200] = {
+            description: "Token",
+            content: {
+                "application/json": {
+                    schema:{
+                        $ref: "#/components/schemas/TokenResponse"
+                    }
+                }
+            }
+        }
+        */
         '/local/signin',
         local.signin
       );

--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -28,26 +28,111 @@ module.exports = class DocsService extends CampsiService {
       req.service = service;
       next();
     });
-    this.router.param('resource', param.attachResource(service.options));
-    this.router.get('/', handlers.getResources);
-    this.router.get('/:resource', handlers.getDocuments);
-    this.router.post('/:resource/:id/locks', handlers.lockDocument);
-    this.router.get('/:resource/:id/locks', handlers.getLocks);
-    this.router.get('/:resource/:id/users', handlers.getDocUsers);
-    this.router.post('/:resource/:id/users', handlers.postDocUser);
-    this.router.delete('/:resource/:id/users/:user', handlers.delDocUser);
-    this.router.post('/:resource/:id/:state/locks', handlers.lockDocument);
-    this.router.get('/:resource/:id/:state', handlers.getDoc);
-    this.router.get('/:resource/:id', handlers.getDoc);
-    this.router.post('/:resource/:state', handlers.postDoc);
-    this.router.post('/:resource', handlers.postDoc);
-    this.router.put('/:resource/:id/state', handlers.putDocState);
-    this.router.put('/:resource/:id/:state', handlers.putDoc);
-    this.router.put('/:resource/:id', handlers.putDoc);
-    this.router.patch('/:resource/:id', handlers.patchDoc);
-    this.router.delete('/:resource/:id', handlers.delDoc);
-    this.router.delete('/:resource/:id/:state', handlers.delDoc);
-    this.router.delete('/:resource/:id/locks/:lock', handlers.deleteLock);
+    this.router.param(
+      // #swagger.tags = ['{DOCSERVICE}']
+      // #swagger.ignore = true
+      'resource',
+      param.attachResource(service.options)
+    );
+    this.router.get(
+      '/',
+      // #swagger.tags = ['DOCSERVICE']
+      // #swagger.ignore = true
+      handlers.getResources
+    );
+    this.router.get(
+      // #swagger.tags = ['DOCSERVICE']
+      '/:resource',
+      handlers.getDocuments
+    );
+    this.router.post(
+      '/:resource/:id/locks',
+      // #swagger.tags = ['DOCSERVICE']
+      // #swagger.ignore = true
+      handlers.lockDocument
+    );
+    this.router.get(
+      '/:resource/:id/locks',
+      // #swagger.ignore = true
+      // #swagger.tags = ['DOCSERVICE']
+      handlers.getLocks
+    );
+    this.router.get(
+      // #swagger.ignore = true
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id/users',
+      handlers.getDocUsers
+    );
+    this.router.post(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id/users',
+      handlers.postDocUser
+    );
+    this.router.delete(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id/users/:user',
+      handlers.delDocUser
+    );
+    this.router.post(
+      '/:resource/:id/:state/locks',
+      // #swagger.ignore = true
+      handlers.lockDocument
+    );
+    this.router.get(
+      // #swagger.tags = ['DOCSERVICE']
+      '/:resource/:id/:state',
+      handlers.getDoc
+    );
+    this.router.get(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id',
+      handlers.getDoc
+    );
+    this.router.post(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:state',
+      handlers.postDoc
+    );
+    this.router.post(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource',
+      handlers.postDoc
+    );
+    this.router.put(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id/state',
+      handlers.putDocState
+    );
+    this.router.put(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id/:state',
+      handlers.putDoc
+    );
+    this.router.put(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id',
+      handlers.putDoc
+    );
+    this.router.patch(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id',
+      handlers.patchDoc
+    );
+    this.router.delete(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id',
+      handlers.delDoc
+    );
+    this.router.delete(
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id/:state',
+      handlers.delDoc
+    );
+    this.router.delete(
+      '/:resource/:id/locks/:lock',
+      // #swagger.ignore = true
+      handlers.deleteLock
+    );
     return new Promise(resolve => {
       const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: false });
       addFormats(ajvWriter);

--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -28,111 +28,26 @@ module.exports = class DocsService extends CampsiService {
       req.service = service;
       next();
     });
-    this.router.param(
-      // #swagger.tags = ['{DOCSERVICE}']
-      // #swagger.ignore = true
-      'resource',
-      param.attachResource(service.options)
-    );
-    this.router.get(
-      '/',
-      // #swagger.tags = ['DOCSERVICE']
-      // #swagger.ignore = true
-      handlers.getResources
-    );
-    this.router.get(
-      // #swagger.tags = ['DOCSERVICE']
-      '/:resource',
-      handlers.getDocuments
-    );
-    this.router.post(
-      '/:resource/:id/locks',
-      // #swagger.tags = ['DOCSERVICE']
-      // #swagger.ignore = true
-      handlers.lockDocument
-    );
-    this.router.get(
-      '/:resource/:id/locks',
-      // #swagger.ignore = true
-      // #swagger.tags = ['DOCSERVICE']
-      handlers.getLocks
-    );
-    this.router.get(
-      // #swagger.ignore = true
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:id/users',
-      handlers.getDocUsers
-    );
-    this.router.post(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:id/users',
-      handlers.postDocUser
-    );
-    this.router.delete(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:id/users/:user',
-      handlers.delDocUser
-    );
-    this.router.post(
-      '/:resource/:id/:state/locks',
-      // #swagger.ignore = true
-      handlers.lockDocument
-    );
-    this.router.get(
-      // #swagger.tags = ['DOCSERVICE']
-      '/:resource/:id/:state',
-      handlers.getDoc
-    );
-    this.router.get(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:id',
-      handlers.getDoc
-    );
-    this.router.post(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:state',
-      handlers.postDoc
-    );
-    this.router.post(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource',
-      handlers.postDoc
-    );
-    this.router.put(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:id/state',
-      handlers.putDocState
-    );
-    this.router.put(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:id/:state',
-      handlers.putDoc
-    );
-    this.router.put(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:id',
-      handlers.putDoc
-    );
-    this.router.patch(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:id',
-      handlers.patchDoc
-    );
-    this.router.delete(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:id',
-      handlers.delDoc
-    );
-    this.router.delete(
-      // #swagger.tags = ['DOCSERVICE'],
-      '/:resource/:id/:state',
-      handlers.delDoc
-    );
-    this.router.delete(
-      '/:resource/:id/locks/:lock',
-      // #swagger.ignore = true
-      handlers.deleteLock
-    );
+    this.router.param('resource', param.attachResource(service.options));
+    this.router.get('/', handlers.getResources);
+    this.router.get('/:resource', handlers.getDocuments);
+    this.router.post('/:resource/:id/locks', handlers.lockDocument);
+    this.router.get('/:resource/:id/locks', handlers.getLocks);
+    this.router.get('/:resource/:id/users', handlers.getDocUsers);
+    this.router.post('/:resource/:id/users', handlers.postDocUser);
+    this.router.delete('/:resource/:id/users/:user', handlers.delDocUser);
+    this.router.post('/:resource/:id/:state/locks', handlers.lockDocument);
+    this.router.get('/:resource/:id/:state', handlers.getDoc);
+    this.router.get('/:resource/:id', handlers.getDoc);
+    this.router.post('/:resource/:state', handlers.postDoc);
+    this.router.post('/:resource', handlers.postDoc);
+    this.router.put('/:resource/:id/state', handlers.putDocState);
+    this.router.put('/:resource/:id/:state', handlers.putDoc);
+    this.router.put('/:resource/:id', handlers.putDoc);
+    this.router.patch('/:resource/:id', handlers.patchDoc);
+    this.router.delete('/:resource/:id', handlers.delDoc);
+    this.router.delete('/:resource/:id/:state', handlers.delDoc);
+    this.router.delete('/:resource/:id/locks/:lock', handlers.deleteLock);
     return new Promise(resolve => {
       const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: false });
       addFormats(ajvWriter);


### PR DESCRIPTION
This is part of a series of changes in campsi that enable swagger-autogen to build swagger docs from the source. **This PR adds the necessary comments to the auth service** that are to be picked up by swagger-autogen and that generates the same swagger doc that is already in place today.

The endpoints that are excluded from the swagger have // #swagger.ignore = true as a comment, to include them remove this comment and provide any extra information such as the parameters used and any return codes