### PR TITLE
fix: update semantic release node version to 18

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 18.x
     - name: Install dependencies
       run: npx ci
     - name: Install semantic-release extra plugins


### PR DESCRIPTION
Semantic-release needs node 18 to run since 2 days ago otherwise it fails and therefore the npm version doesn't update automatically.

This should not impact the node version used by campsi.