### PR TITLE
fix: sort and creator options not working correctly

### DIFF
--- a/lib/modules/sortCursor.js
+++ b/lib/modules/sortCursor.js
@@ -5,7 +5,7 @@
  * @returns {Array<Array>}
  */
 function getMongoSortArray(field, prefix) {
-  return !field.startsWith('-') ? [prefix + field, 1] : [prefix + field.substr(1), -1];
+  return !field.startsWith('-') ? { [prefix + field]: 1 } : { [prefix + field.substr(1)]: -1 };
 }
 
 /**
@@ -16,14 +16,25 @@ function getMongoSortArray(field, prefix) {
  * @param {String} [prefix]
  * @return {Cursor} cursor
  */
-module.exports = (cursor, sort, prefix) => {
+module.exports = (cursor, sort, prefix, getFields) => {
   if (typeof sort === 'undefined') {
     return cursor;
   }
 
   prefix = prefix === undefined ? '' : String(prefix);
 
-  const fields = sort.split(',').map(field => getMongoSortArray(field, prefix));
+  if (prefix?.includes('data.')) {
+    sort = sort.replaceAll('data.', '');
+  }
+
+  let fields = {};
+
+  sort.split(',').forEach(field => (fields = { ...fields, ...getMongoSortArray(field, prefix) }));
+
+  if (getFields) {
+    return fields;
+  }
+
   cursor.sort(fields);
   return cursor;
 };

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -248,6 +248,12 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
     $project: dbFields
   });
 
+  if (sort) {
+    pipeline.push({
+      // eslint-disable-next-line indexof/no-indexof
+      $sort: sortCursor(null, sort, sort.indexOf('data') === 0 ? 'states.{}.data.'.format(state) : '', true)
+    });
+  }
   const cursor = !aggregate
     ? resource.collection.find(dbQuery, { projection: dbFields })
     : resource.collection.aggregate(pipeline);
@@ -269,7 +275,7 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
         if (info.page < info.lastPage) {
           result.nav.next = info.page + 1;
         }
-        if (sort) {
+        if (sort && !aggregate) {
           // eslint-disable-next-line indexof/no-indexof
           sortCursor(cursor, sort, sort.indexOf('data') === 0 ? 'states.{}.data.'.format(state) : '');
         }


### PR DESCRIPTION
PR fixes an issue whereby the field names extracted from incoming user query to be used in sort filter where not being correctly assembled causing the sort option to not be taken into account. 

The same issue was causing the with=creator option to cause mongodb to reject the query and cause an error