### PR TITLE
Jameslotery/dev 2664

### DIFF
--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -71,8 +71,9 @@ module.exports = class DocsService extends CampsiService {
       handlers.postDocUser
     );
     this.router.delete(
-      // #swagger.tags = ['DOCSERVICE'],
-      // #swagger.ignore = true
+      /* #swagger.tags = ['DOCSERVICE'],
+         #swagger.ignore = true
+      */
       '/:resource/:id/users/:user',
       handlers.delDocUser
     );
@@ -88,8 +89,27 @@ module.exports = class DocsService extends CampsiService {
       handlers.getDoc
     );
     this.router.get(
-      // #swagger.tags = ['DOCSERVICE'],
-      // #swagger.summary = 'DOCS_GET_RESOURCE_ID_SUMMARY'
+      /* #swagger.tags = ['DOCSERVICE'],
+      #swagger.summary = 'DOCS_GET_RESOURCE_ID_SUMMARY'
+       #swagger.parameters['dummy']={}
+      #swagger.requestBody = {
+        required: true,
+        content: {
+            "application/json": {
+                schema: { $ref: "#/components/schemas/CreateProjectRequest" }
+            }
+        }
+      }
+      #swagger.responses[200] = {
+          description: "Token",
+          content: {
+              "application/json": {
+                  schema:{
+                      $ref: "#/components/schemas/VaultProjectResponse"
+                  }
+              }
+          }
+      } */
       '/:resource/:id',
       handlers.getDoc
     );
@@ -100,8 +120,26 @@ module.exports = class DocsService extends CampsiService {
       handlers.postDoc
     );
     this.router.post(
-      // #swagger.tags = ['DOCSERVICE'],
-      // #swagger.summary = 'DOCS_POST_RESOURCE_SUMMARY'
+      /* #swagger.tags = ['DOCSERVICE'],
+         #swagger.summary = 'DOCS_POST_RESOURCE_SUMMARY'
+         #swagger.requestBody = {
+          required: true,
+            content: {
+                "application/json": {
+                    schema: { $ref: "#/components/schemas/CreateProjectRequest" }
+                }
+            }
+        }
+        #swagger.responses[200] = {
+            description: "Token",
+            content: {
+                "application/json": {
+                    schema:{
+                        $ref: "#/components/schemas/VaultProjectResponse"
+                    }
+                }
+            }
+        } */
       '/:resource',
       handlers.postDoc
     );
@@ -118,8 +156,27 @@ module.exports = class DocsService extends CampsiService {
       handlers.putDoc
     );
     this.router.put(
-      // #swagger.tags = ['DOCSERVICE'],
-      // #swagger.summary = 'DOCS_PUT_RESOURCE_ID_SUMMARY'
+      /* #swagger.tags = ['DOCSERVICE'],
+      #swagger.parameters['resource']={}
+      #swagger.summary = 'DOCS_PUT_RESOURCE_ID_SUMMARY'
+      #swagger.requestBody = {
+        required: true,
+          content: {
+              "application/json": {
+                  schema: { $ref: "#/components/schemas/CreateProjectRequest" }
+              }
+          }
+      }
+      #swagger.responses[200] = {
+          description: "Token",
+          content: {
+              "application/json": {
+                  schema:{
+                      $ref: "#/components/schemas/VaultProjectResponse"
+                  }
+              }
+          }
+      } */
       '/:resource/:id',
       handlers.putDoc
     );
@@ -130,8 +187,26 @@ module.exports = class DocsService extends CampsiService {
       handlers.patchDoc
     );
     this.router.delete(
-      // #swagger.tags = ['DOCSERVICE'],
-      // #swagger.summary = 'DOCS_DELETE_RESOURCE_ID_SUMMARY'
+      /* #swagger.tags = ['DOCSERVICE'],
+      #swagger.summary = 'DOCS_DELETE_RESOURCE_ID_SUMMARY'
+      #swagger.requestBody = {
+        required: true,
+          content: {
+              "application/json": {
+                  schema: { $ref: "#/components/schemas/CreateProjectRequest" }
+              }
+          }
+      }
+      #swagger.responses[200] = {
+          description: "Token",
+          content: {
+              "application/json": {
+                  schema:{
+                      $ref: "#/components/schemas/VaultProjectResponse"
+                  }
+              }
+          }
+      } */
       '/:resource/:id',
       handlers.delDoc
     );

--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -28,26 +28,124 @@ module.exports = class DocsService extends CampsiService {
       req.service = service;
       next();
     });
-    this.router.param('resource', param.attachResource(service.options));
-    this.router.get('/', handlers.getResources);
-    this.router.get('/:resource', handlers.getDocuments);
-    this.router.post('/:resource/:id/locks', handlers.lockDocument);
-    this.router.get('/:resource/:id/locks', handlers.getLocks);
-    this.router.get('/:resource/:id/users', handlers.getDocUsers);
-    this.router.post('/:resource/:id/users', handlers.postDocUser);
-    this.router.delete('/:resource/:id/users/:user', handlers.delDocUser);
-    this.router.post('/:resource/:id/:state/locks', handlers.lockDocument);
-    this.router.get('/:resource/:id/:state', handlers.getDoc);
-    this.router.get('/:resource/:id', handlers.getDoc);
-    this.router.post('/:resource/:state', handlers.postDoc);
-    this.router.post('/:resource', handlers.postDoc);
-    this.router.put('/:resource/:id/state', handlers.putDocState);
-    this.router.put('/:resource/:id/:state', handlers.putDoc);
-    this.router.put('/:resource/:id', handlers.putDoc);
-    this.router.patch('/:resource/:id', handlers.patchDoc);
-    this.router.delete('/:resource/:id', handlers.delDoc);
-    this.router.delete('/:resource/:id/:state', handlers.delDoc);
-    this.router.delete('/:resource/:id/locks/:lock', handlers.deleteLock);
+    this.router.param(
+      // #swagger.tags = ['{DOCSERVICE}']
+      // #swagger.ignore = true
+      'resource',
+      param.attachResource(service.options)
+    );
+    this.router.get(
+      '/',
+      // #swagger.tags = ['DOCSERVICE']
+      // #swagger.ignore = true
+      handlers.getResources
+    );
+    this.router.get(
+      // #swagger.tags = ['DOCSERVICE']
+      // #swagger.ignore = true
+      '/:resource',
+      handlers.getDocuments
+    );
+    this.router.post(
+      '/:resource/:id/locks',
+      // #swagger.tags = ['DOCSERVICE']
+      // #swagger.ignore = true
+      handlers.lockDocument
+    );
+    this.router.get(
+      '/:resource/:id/locks',
+      // #swagger.ignore = true
+      // #swagger.tags = ['DOCSERVICE']
+      handlers.getLocks
+    );
+    this.router.get(
+      // #swagger.ignore = true
+      // #swagger.tags = ['DOCSERVICE'],
+      '/:resource/:id/users',
+      handlers.getDocUsers
+    );
+    this.router.post(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.ignore = true
+      '/:resource/:id/users',
+      handlers.postDocUser
+    );
+    this.router.delete(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.ignore = true
+      '/:resource/:id/users/:user',
+      handlers.delDocUser
+    );
+    this.router.post(
+      '/:resource/:id/:state/locks',
+      // #swagger.ignore = true
+      handlers.lockDocument
+    );
+    this.router.get(
+      // #swagger.tags = ['DOCSERVICE']
+      // #swagger.ignore = true
+      '/:resource/:id/:state',
+      handlers.getDoc
+    );
+    this.router.get(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.summary = 'DOCS_GET_RESOURCE_ID_SUMMARY'
+      '/:resource/:id',
+      handlers.getDoc
+    );
+    this.router.post(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.ignore = true
+      '/:resource/:state',
+      handlers.postDoc
+    );
+    this.router.post(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.summary = 'DOCS_POST_RESOURCE_SUMMARY'
+      '/:resource',
+      handlers.postDoc
+    );
+    this.router.put(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.ignore = true
+      '/:resource/:id/state',
+      handlers.putDocState
+    );
+    this.router.put(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.ignore = true
+      '/:resource/:id/:state',
+      handlers.putDoc
+    );
+    this.router.put(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.summary = 'DOCS_PUT_RESOURCE_ID_SUMMARY'
+      '/:resource/:id',
+      handlers.putDoc
+    );
+    this.router.patch(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.ignore = true
+      '/:resource/:id',
+      handlers.patchDoc
+    );
+    this.router.delete(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.summary = 'DOCS_DELETE_RESOURCE_ID_SUMMARY'
+      '/:resource/:id',
+      handlers.delDoc
+    );
+    this.router.delete(
+      // #swagger.tags = ['DOCSERVICE'],
+      // #swagger.ignore = true
+      '/:resource/:id/:state',
+      handlers.delDoc
+    );
+    this.router.delete(
+      '/:resource/:id/locks/:lock',
+      // #swagger.ignore = true
+      handlers.deleteLock
+    );
     return new Promise(resolve => {
       const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: false });
       addFormats(ajvWriter);

--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -91,21 +91,15 @@ module.exports = class DocsService extends CampsiService {
     this.router.get(
       /* #swagger.tags = ['DOCSERVICE'],
       #swagger.summary = 'DOCS_GET_RESOURCE_ID_SUMMARY'
-       #swagger.parameters['dummy']={}
-      #swagger.requestBody = {
-        required: true,
-        content: {
-            "application/json": {
-                schema: { $ref: "#/components/schemas/CreateProjectRequest" }
-            }
+      #swagger.parameters['id']={
+          description: "DOCS_GET_ID_PARAM_DESCRIPTION"
         }
-      }
       #swagger.responses[200] = {
-          description: "Token",
+          description: "DOCS_GET_RESPONSE_DESCRIPTION",
           content: {
               "application/json": {
                   schema:{
-                      $ref: "#/components/schemas/VaultProjectResponse"
+                      $ref: "DOCS_RESPONSE_SCHEMA"
                   }
               }
           }
@@ -126,16 +120,16 @@ module.exports = class DocsService extends CampsiService {
           required: true,
             content: {
                 "application/json": {
-                    schema: { $ref: "#/components/schemas/CreateProjectRequest" }
+                    schema: { $ref: "DOCS_WRITE_SCHEMA" }
                 }
             }
         }
         #swagger.responses[200] = {
-            description: "Token",
+            description: "DOCS_POST_RESPONSE_DESCRIPTION",
             content: {
                 "application/json": {
                     schema:{
-                        $ref: "#/components/schemas/VaultProjectResponse"
+                        $ref: "DOCS_RESPONSE_SCHEMA"
                     }
                 }
             }
@@ -157,22 +151,24 @@ module.exports = class DocsService extends CampsiService {
     );
     this.router.put(
       /* #swagger.tags = ['DOCSERVICE'],
-      #swagger.parameters['resource']={}
       #swagger.summary = 'DOCS_PUT_RESOURCE_ID_SUMMARY'
+      #swagger.parameters['id']={
+          description: "DOCS_PUT_ID_PARAM_DESCRIPTION"
+      }
       #swagger.requestBody = {
         required: true,
           content: {
               "application/json": {
-                  schema: { $ref: "#/components/schemas/CreateProjectRequest" }
+                  schema: { $ref: "DOCS_WRITE_SCHEMA" }
               }
           }
       }
       #swagger.responses[200] = {
-          description: "Token",
+          description: "DOCS_PUT_RESPONSE_DESCRIPTION",
           content: {
               "application/json": {
                   schema:{
-                      $ref: "#/components/schemas/VaultProjectResponse"
+                      $ref: "DOCS_RESPONSE_SCHEMA"
                   }
               }
           }
@@ -189,24 +185,20 @@ module.exports = class DocsService extends CampsiService {
     this.router.delete(
       /* #swagger.tags = ['DOCSERVICE'],
       #swagger.summary = 'DOCS_DELETE_RESOURCE_ID_SUMMARY'
-      #swagger.requestBody = {
-        required: true,
-          content: {
-              "application/json": {
-                  schema: { $ref: "#/components/schemas/CreateProjectRequest" }
-              }
-          }
+      #swagger.parameters['id']={
+          description: "DOCS_DELETE_ID_PARAM_DESCRIPTION"
       }
       #swagger.responses[200] = {
-          description: "Token",
+          description: "DOCS_DELETE_RESPONSE_DESCRIPTION",
           content: {
               "application/json": {
                   schema:{
-                      $ref: "#/components/schemas/VaultProjectResponse"
+                      type: "object"
                   }
               }
           }
-      } */
+        }
+      */
       '/:resource/:id',
       handlers.delDoc
     );


### PR DESCRIPTION
This is part of a series of changes in campsi that enable swagger-autogen to build swagger docs from the source. This PR adds the necessary comments to the DOCS service that are to be picked up by swagger-autogen and that generates the same swagger doc that is already in place today.

The endpoints that are excluded from the swagger have // #swagger.ignore = true as a comment, to include them remove this comment and provide any extra information such as the parameters used and any return codes

The following constants are put in place in the swagger documentation and are overrided and replaced in the service that generates the docs (in this case Caas-API) :

DOCS_PUT_RESOURCE_ID_SUMMARY
DOCS_DELETE_RESOURCE_ID_SUMMARY
DOCS_POST_RESOURCE_SUMMARY
DOCS_GET_RESOURCE_ID_SUMMARY
DOCS_POST_RESPONSE_DESCRIPTION
DOCS_DELETE_RESPONSE_DESCRIPTION
DOCS_PUT_RESPONSE_DESCRIPTION
DOCS_GET_ID_PARAM_DESCRIPTION
DOCS_GET_RESPONSE_DESCRIPTION
DOCS_DELETE_ID_PARAM_DESCRIPTION
DOCS_PUT_ID_PARAM_DESCRIPTION
DOCS_WRITE_SCHEMA
DOCS_RESPONSE_SCHEMA

These constants are place holders for parameter descriptions, input values or return values.
 see (https://github.com/axeptio/caas-api/tree/jameslotery/dev-2410 for the service that overrides these values)