### PR TITLE
handle cases of reverse triage

### DIFF
--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -251,7 +251,7 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
   if (sort) {
     pipeline.push({
       // eslint-disable-next-line indexof/no-indexof
-      $sort: sortCursor(null, sort, (sort.indexOf('data') === 0  || sort.indexOf('-data') === 0) ? 'states.{}.data.'.format(state) : '', true)
+      $sort: sortCursor(null, sort, (sort.startsWith('data') || sort. startsWith('-data')) ? 'states.{}.data.'.format(state) : '', true)
     });
   }
   const cursor = !aggregate

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -251,7 +251,7 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
   if (sort) {
     pipeline.push({
       // eslint-disable-next-line indexof/no-indexof
-      $sort: sortCursor(null, sort, sort.indexOf('data') === 0 ? 'states.{}.data.'.format(state) : '', true)
+      $sort: sortCursor(null, sort, (sort.indexOf('data') === 0  || sort.indexOf('-data') === 0) ? 'states.{}.data.'.format(state) : '', true)
     });
   }
   const cursor = !aggregate


### PR DESCRIPTION
PR fixes an issue whereby the field names extracted from incoming user query to be used in sort filter where not being correctly assembled causing the sort option to not be taken into account. 

The same issue was causing the with=creator option to cause mongodb to reject the query and cause an error