### PR TITLE
feat: add unit tests for sort

### DIFF
--- a/test/docs/pagination.js
+++ b/test/docs/pagination.js
@@ -135,14 +135,14 @@ describe('Pagination', () => {
       pizzas.should.be.a('array');
       pizzas.length.should.be.eq(100);
 
-      // check first 5 entries are in the correct order
+      // check last 5 entries are in the correct order
       pizzas[99]?.data?.name.should.be.eq('margherita_0');
       pizzas[98]?.data?.name.should.be.eq('margherita_1');
       pizzas[97]?.data?.name.should.be.eq('margherita_10');
       pizzas[96]?.data?.name.should.be.eq('margherita_11');
       pizzas[95]?.data?.name.should.be.eq('margherita_12');
 
-      // check last 5 entries are in the correct order
+      // check first 5 entries are in the correct order
       pizzas[4]?.data?.name.should.be.eq('margherita_95');
       pizzas[3]?.data?.name.should.be.eq('margherita_96');
       pizzas[2]?.data?.name.should.be.eq('margherita_97');

--- a/test/docs/pagination.js
+++ b/test/docs/pagination.js
@@ -122,6 +122,59 @@ describe('Pagination', () => {
     });
   });
 
+   /*
+   * Test the /GET docs/pizzas route
+   */
+   describe('Test sort', () => {
+    it('it should GET all the pizzas sorted by name in reverse order', async() => {
+      const res = await chai.request(campsi.app).get('/docs/pizzas/?sort=-data.name');
+    
+      const pizzas = res?.body;
+
+      res.should.have.status(200);
+      pizzas.should.be.a('array');
+      pizzas.length.should.be.eq(100);
+
+      // check first 5 entries are in the correct order
+      pizzas[99]?.data?.name.should.be.eq('margherita_0');
+      pizzas[98]?.data?.name.should.be.eq('margherita_1');
+      pizzas[97]?.data?.name.should.be.eq('margherita_10');
+      pizzas[96]?.data?.name.should.be.eq('margherita_11');
+      pizzas[95]?.data?.name.should.be.eq('margherita_12');
+
+      // check last 5 entries are in the correct order
+      pizzas[4]?.data?.name.should.be.eq('margherita_95');
+      pizzas[3]?.data?.name.should.be.eq('margherita_96');
+      pizzas[2]?.data?.name.should.be.eq('margherita_97');
+      pizzas[1]?.data?.name.should.be.eq('margherita_98');
+      pizzas[0]?.data?.name.should.be.eq('margherita_99');
+    });
+
+    it('it should GET all the pizzas sorted by name in alphabetical order', async () => {
+        const res = await chai.request(campsi.app).get('/docs/pizzas/?sort=data.name');
+    
+        const pizzas = res?.body;
+
+        res.should.have.status(200);
+        pizzas.should.be.a('array');
+        pizzas.length.should.be.eq(100);
+
+        // check first 5 entries are in the correct order
+        pizzas[0]?.data?.name.should.be.eq('margherita_0');
+        pizzas[1]?.data?.name.should.be.eq('margherita_1');
+        pizzas[2]?.data?.name.should.be.eq('margherita_10');
+        pizzas[3]?.data?.name.should.be.eq('margherita_11');
+        pizzas[4]?.data?.name.should.be.eq('margherita_12');
+
+        // check last 5 entries are in the correct order
+        pizzas[95]?.data?.name.should.be.eq('margherita_95');
+        pizzas[96]?.data?.name.should.be.eq('margherita_96');
+        pizzas[97]?.data?.name.should.be.eq('margherita_97');
+        pizzas[98]?.data?.name.should.be.eq('margherita_98');
+        pizzas[99]?.data?.name.should.be.eq('margherita_99');
+    });
+  });
+
   /*
    * Test the /GET docs/pizzas route
    */


### PR DESCRIPTION
This PR adds two tests one that does retrieves a test data set in sorted order and the other that retrieves the test data set sorted in reverse order.

The data set contains 100 entries (pizza_0 to pizza_99).

The last 5 and first 5 entries of the returned data sets are examined to make sure they are in the right order.