### PR TITLE
refactor: update mongodb driver (DEV-2814)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ A document is an instance of a resource. It has an `id` and a value for each def
 #### Anatomy of a document
 ```javascript
 let doc = {
-	id: ObjectId("58205e4fa5dc6c3b381a0e9b"),
+	id: new ObjectId("58205e4fa5dc6c3b381a0e9b"),
     states: {
     	published: {
         	createdAt: "2016-11-07 10:58:23.950Z",

--- a/lib/modules/createObjectId.js
+++ b/lib/modules/createObjectId.js
@@ -7,7 +7,7 @@ const { ObjectId } = require('mongodb');
  * @returns {undefined|ObjectId}
  */
 module.exports = function createObjectId(str) {
-  const oid = ObjectId.isValid(str?.toString()) ? ObjectId(str) : undefined;
+  const oid = ObjectId.isValid(str?.toString()) ? new ObjectId(str) : undefined;
   if (!oid) debug('wrong object id %s', str);
   return oid;
 };

--- a/lib/modules/paginateCursor.js
+++ b/lib/modules/paginateCursor.js
@@ -28,36 +28,17 @@ module.exports = function paginateCursor(cursor, options) {
       return resolve({ skip, limit, page, perPage });
     }
 
-    const isAggregationCursor = cursor instanceof AggregationCursor;
-    if (!isAggregationCursor) {
-      cursor
-        .count()
-        .then(count => {
-          cursor.skip(skip).limit(limit);
-          return resolve(preparePagination(count, skip, limit, page, perPage));
-        })
-        .catch(error => {
-          reject(error);
-        });
-    } else {
-      /*
-        since count() doesn't exist with AggregationCursor
-        Note: I could have used the code below for both types of cursor
-        (FindCursor and AggregationCursor), but since count() doesn't perform the query,
-        I guessed that it would be better for performances to handle the count differently
-       */
-      cursor
-        .toArray()
-        .then(documents => {
-          const count = documents.length;
-          cursor.rewind();
-          cursor.skip(skip).limit(limit);
-          return resolve(preparePagination(count, skip, limit, page, perPage));
-        })
-        .catch(error => {
-          reject(error);
-        });
-    }
+    cursor
+      .toArray()
+      .then(documents => {
+        const count = documents.length;
+        cursor.rewind();
+        cursor.skip(skip).limit(limit);
+        return resolve(preparePagination(count, skip, limit, page, perPage));
+      })
+      .catch(error => {
+        reject(error);
+      });
   });
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -65,12 +65,12 @@ class CampsiServer extends MQTTEmitter {
     this.services.set(path, service);
   }
 
-  start() {
-    return this.dbConnect()
-      .then(() => this.setupApp())
-      .then(() => this.loadServices())
-      .then(() => this.describe())
-      .then(() => this.finalizeSetup());
+  async start() {
+    await this.dbConnect();
+    await this.setupApp();
+    await this.loadServices();
+    await this.describe();
+    await this.finalizeSetup();
   }
 
   async dbConnect() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,7 +20,7 @@ function ServiceException(path, service, message) {
   this.service = service;
 }
 
-const pinoHttpDefaultOptions = (config) => {
+const pinoHttpDefaultOptions = config => {
   return {
     level: 'silent',
     formatters: {
@@ -73,17 +73,11 @@ class CampsiServer extends MQTTEmitter {
       .then(() => this.finalizeSetup());
   }
 
-  dbConnect() {
+  async dbConnect() {
     const campsiServer = this;
-    return new Promise((resolve, reject) => {
-      const mongoUri = campsiServer.config.mongo.uri;
-      MongoClient.connect(mongoUri, (err, client) => {
-        if (err) return reject(err);
-        campsiServer.dbClient = client;
-        campsiServer.db = client.db(campsiServer.config.mongo.database);
-        resolve();
-      });
-    });
+    const client = await MongoClient.connect(campsiServer.config.mongo.uri);
+    campsiServer.dbClient = client;
+    campsiServer.db = client.db(campsiServer.config.mongo.database);
   }
 
   setupApp() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "body-parser": "^1.18.2",
         "debug": "^3.2.6",
         "express": "^4.16.4",
-        "mongodb": "^4.3.0"
+        "mongodb": "^5.0.0"
       }
     },
     "node_modules/@awaitjs/express": {
@@ -97,6 +97,1079 @@
       "peerDependencies": {
         "@types/express": "4.x",
         "express": "4.x"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.257.0.tgz",
+      "integrity": "sha512-ekWy391lOerS0ZECdhp/c+X7AToJIpfNrCPjuj3bKr+GMQYckGsYsdbm6AUD4sxBmfvuaQmVniSXWovaxwcFcQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.264.0.tgz",
+      "integrity": "sha512-afOpX6/xKLKRjkbgzfuy9fxCVP+LXCiirjBxhEtpUbKjVOwvShbQXfCPDlG40s5HF485mmR9t0KADoy0El5WsA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.264.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-node": "3.264.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.264.0.tgz",
+      "integrity": "sha512-p+7sYpRcdv9omnnsPhD/vOFuZ1SpfV62ZgistBK/RDsQg2W9SIWQRW1KPt7gOCQ0nwp4efntw4Sle0LjS7ykxg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.264.0.tgz",
+      "integrity": "sha512-82hGEbfsD4lBGIF1q8o82jTNSgBCcBpfFsvA+ltZf0bh4ChIWOi4vVvg8G+zVQN1mm/Rj8vWYO/D0tNF8OSyWw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.264.0.tgz",
+      "integrity": "sha512-sco1jREkDdds4Z3V19Vlu/YpBHSzeEt1KFqOPnbjFw7pSakRNzpyWmLLxOwWjwgGKt6pSF3Aw0ZOMYsAUDc5qQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-node": "3.264.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-sdk-sts": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.259.0.tgz",
+      "integrity": "sha512-gViMRsc4Ye6+nzJ0OYTZIT8m4glIAdtugN2Sr/t6P2iJW5X0bSL/EcbcHBgsve1lHjeGPeyzVkT7UnyGOZ5Z/A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.264.0.tgz",
+      "integrity": "sha512-0L4offTpZJrX4PkoUI5KXPlG3uaofbmew+tgPphKd+ns3tzhLsltPMixS/04J5qXEfwMCHwvDgSpCenKsUo/wg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.264.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.257.0.tgz",
+      "integrity": "sha512-GsmBi5Di6hk1JAi1iB6/LCY8o+GmlCvJoB7wuoVmXI3VxRVwptUVjuj8EtJbIrVGrF9dSuIRPCzUoSuzEzYGlg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.259.0.tgz",
+      "integrity": "sha512-yCxoYWZAaDrCUEWxRfrpB0Mp1cFgJEMYW8T6GIb/+DQ5QLpZmorgaVD/j90QXupqFrR5tlxwuskBIkdD2E9YNg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.264.0.tgz",
+      "integrity": "sha512-UU5NNlfn+Go+5PLBzyTH1YE3r/pgykpE4QYFon87sCnEQnQH9xmlRTW1f1cBSQ9kivbFZd2/C2X3qhB3fe2JfA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.264.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.264.0.tgz",
+      "integrity": "sha512-DPzL7oawcILs5Mduim9Z8SVeJaUpaDRVbUIrBHsMBu+N7Zuqtzr+0ckHc1bEi3iYq2QUCk5pH5vpQaZYkMlbtw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/credential-provider-ini": "3.264.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.264.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.257.0.tgz",
+      "integrity": "sha512-xK8uYeNXaclaBCGrLi4z2pxPRngqLf5BM5jg2fn57zqvlL9V5gJF972FehrVBL0bfp1/laG0ZJtD2K2sapyWAw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.264.0.tgz",
+      "integrity": "sha512-CJuAlqIIJap6LXoqimvEAnYZ7Kb5pTbiS3e+aY+fajO3OPujmQpHuiY8kOmscjwZ4ErJdEskivcTGwXph0dPZQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.264.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/token-providers": "3.264.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.257.0.tgz",
+      "integrity": "sha512-Cm0uvRv4JuIbD0Kp3W0J/vwjADIyCx8HoZi5yg+QIi5nilocuTQ3ajvLeuPVSvFvdy+yaxSc5FxNXquWt7Mngw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.264.0.tgz",
+      "integrity": "sha512-4iSr1Z7Uf8uDraQ7JYoMotVLhmnGFAGsH559KBPxuxjMjg2lku9GA5V1zw7SNV8FEcj+Sh5HrpJvJ7P1kA+YjA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.264.0",
+        "@aws-sdk/client-sso": "3.264.0",
+        "@aws-sdk/client-sts": "3.264.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.264.0",
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/credential-provider-ini": "3.264.0",
+        "@aws-sdk/credential-provider-node": "3.264.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.264.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.257.0.tgz",
+      "integrity": "sha512-zOF+RzQ+wfF7tq7tGUdPcqUTh3+k2f8KCVJE07A8kCopVq4nBu4NH6Eq29Tjpwdya3YlKvE+kFssuQRRRRex+Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/querystring-builder": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.257.0.tgz",
+      "integrity": "sha512-W/USUuea5Ep3OJ2U7Ve8/5KN1YsDun2WzOFUxc1PyxXP5pW6OgC15/op0e+bmWPG851clvp5S8ZuroUr3aKi3Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.257.0.tgz",
+      "integrity": "sha512-T68SAPRNMEhpke0wlxURgogL7q0B8dfqZsSeS20BVR/lksJxLse9+pbmCDxiu1RrXoEIsEwl5rbLN+Hw8BFFYw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.257.0.tgz",
+      "integrity": "sha512-yiawbV2azm6QnMY1L2ypG8PDRdjOcEIvFmT0T7y0F49rfbKJOu21j1ONAoCkLrINK6kMqcD5JSQLVCoURxiTxQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.264.0.tgz",
+      "integrity": "sha512-H9JEAug3Oo3IA2wZIplVVF6NtauCIjICXWgbNbA8Im+I2KPe0jWtOdtQv4U+tqHe9T4zIixaCM3gjUBld+FoOA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.257.0.tgz",
+      "integrity": "sha512-gEi9AJdJfRfU8Qr6HK1hfhxTzyV3Giq4B/h7um99hIFAT/GCg9xiPvAOKPo6UeuiKEv3b7RpSL4s6cBvnJMJBA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.257.0.tgz",
+      "integrity": "sha512-8RDXW/VbMKBsXDfcCLmROZcWKyrekyiPa3J1aIaBy0tq9o4xpGoXw/lwwIrNVvISAFslb57rteup34bfn6ta6w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.257.0.tgz",
+      "integrity": "sha512-rUCih6zHh8k9Edf5N5Er4s508FYbwLM0MWTD2axzlj9TjLqEQ9OKED3wHaLffXSDzodd3oTAfJCLPbWQyoZ3ZQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.259.0.tgz",
+      "integrity": "sha512-pVh1g8e84MAi7eVtWLiiiCtn82LzxOP7+LxTRHatmgIeN22yGQBZILliPDJypUPvDYlwxI1ekiK+oPTcte0Uww==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/service-error-classification": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.257.0.tgz",
+      "integrity": "sha512-d6IJCLRi3O2tm4AFK60WNhIwmMmspj1WzKR1q1TaoPzoREPG2xg+Am18wZBRkCyYuRPPrbizmkvAmAJiUolMAw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.257.0.tgz",
+      "integrity": "sha512-/JasfXPWFq24mnCrx9fxW/ISBSp07RJwhsF14qzm8Qy3Z0z470C+QRM6otTwAkYuuVt1wuLjja5agq3Jtzq7dQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.257.0.tgz",
+      "integrity": "sha512-hCH3D83LHmm6nqmtNrGTWZCVjsQXrGHIXbd17/qrw7aPFvcAhsiiCncGFP+XsUXEKa2ZqcSNMUyPrx69ofNRZQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.257.0.tgz",
+      "integrity": "sha512-awg2F0SvwACBaw4HIObK8pQGfSqAc4Vy+YFzWSfZNVC35oRO6RsRdKHVU99lRC0LrT2Ptmfghl2DMPSrRDbvlQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.257.0.tgz",
+      "integrity": "sha512-37rt75LZyD0UWpbcFuxEGqwF3DZKSixQPl7AsDe6q3KtrO5gGQB+diH5vbY0txNNYyv5IK9WMwvY73mVmoWRmw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.259.0.tgz",
+      "integrity": "sha512-DUOqr71oonBvM6yKPdhDBmraqgXHCFrVWFw7hc5ZNxL2wS/EsbKfGPJp+C+SUgpn1upIWPNnh/bNoLAbBkcLsA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.257.0.tgz",
+      "integrity": "sha512-8KnWHVVwaGKyTlkTU9BSOAiSovNDoagxemU2l10QqBbzUCVpljCUMUkABEGRJ1yoQCl6DJ7RtNkAyZ8Ne/E15A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/querystring-builder": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.257.0.tgz",
+      "integrity": "sha512-3rUbRAcF0GZ5PhDiXhS4yREfZ5hOEtvYEa9S/19OdM5eoypOaLU5XnFcCKfnccSP8SkdgpJujzxOMRWNWadlAQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.257.0.tgz",
+      "integrity": "sha512-xt7LGOgZIvbLS3418AYQLacOqx+mo5j4mPiIMz7f6AaUg+/fBUgESVsncKDqxbEJVwwCXSka8Ca0cntJmoeMSw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.257.0.tgz",
+      "integrity": "sha512-mZHWLP7XIkzx1GIXO5WfX/iJ+aY9TWs02RE9FkdL2+by0HEMR65L3brQTbU1mIBJ7BjaPwYH24dljUOSABX7yg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.257.0.tgz",
+      "integrity": "sha512-UDrE1dEwWrWT8dG2VCrGYrPxCWOkZ1fPTPkjpkR4KZEdQDZBqU5gYZF2xPj8Nz7pjQVHFuW2wFm3XYEk56GEjg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.257.0.tgz",
+      "integrity": "sha512-FAyR0XsueGkkqDtkP03cTJQk52NdQ9sZelLynmmlGPUP75LApRPvFe1riKrou6+LsDbwVNVffj6mbDfIcOhaOw==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.257.0.tgz",
+      "integrity": "sha512-HNjC1+Wx3xHiJc+CP14GhIdVhfQGSjroAsWseRxAhONocA9Fl1ZX4hx7+sA5c9nOoMVOovi6ivJ/6lCRPTDRrQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.257.0.tgz",
+      "integrity": "sha512-aLQQN59X/D0+ShzPD3Anj5ntdMA/RFeNLOUCDyDvremViGi6yxUS98usQ/8bG5Rq0sW2GGMdbFUFmrDvqdiqEQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.261.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.261.0.tgz",
+      "integrity": "sha512-j8XQEa3caZUVFVZfhJjaskw80O/tB+IXu84HMN44N7UkXaCFHirUsNjTDztJhnVXf/gKXzIqUqprfRnOvwLtIg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.264.0.tgz",
+      "integrity": "sha512-1N54FCdBJRqrwFWHUoDpGI0rKhI29Or9ZwGjjcBzKzLhz5sEF/DEhuID7h1/KKEkXdQ0+lmXOFGMMrahrMpOow==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.264.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.257.0.tgz",
+      "integrity": "sha512-LmqXuBQBGeaGi/3Rp7XiEX1B5IPO2UUfBVvu0wwGqVsmstT0SbOVDZGPmxygACbm64n+PRx3uTSDefRfoiWYZg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.257.0.tgz",
+      "integrity": "sha512-Qe/AcFe/NFZHa6cN2afXEQn9ehXxh57dWGdRjfjd2lQqNV4WW1R2pl2Tm1ZJ1dwuCNLJi4NHLMk8lrD3QQ8rdg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.261.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.261.0.tgz",
+      "integrity": "sha512-lX3X1NfzQVV6cakepGV24uRcqevlDnQ8VgaCV8dhnw1FVThueFigyoFaUA02+uRXbV9KIbNWkEvweNtm2wvyDw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.261.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.261.0.tgz",
+      "integrity": "sha512-4AK6yu4bOmHSocUdbGoEHbNXB09UA58ON2HBHY4NxMBuFBAd9XB2tYiyhce+Cm+o+lHbS8oQnw0VZw16WMzzew==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.257.0.tgz",
+      "integrity": "sha512-3bvmRn5XGYzPPWjLuvHBKdJOb+fijnb8Ungu9bfXnTYFsng/ndHUWeHC22O/p8w3OWoRYUIMaZHxdxe27BFozg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.257.0.tgz",
+      "integrity": "sha512-F9ieon8B8eGVs5tyZtAIG3DZEObDvujkspho0qRbUTHUosM0ylJLsMU800fmC/uRHLRrZvb/RSp59+kNDwSAMw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.257.0.tgz",
+      "integrity": "sha512-l9TOsOAYtZxwW3q5fQKW4rsD9t2HVaBfQ4zBamHkNTfB4vBVvCnz4oxkvSvA2MlxCA6am+K1K/oj917Tpqk53g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.257.0.tgz",
+      "integrity": "sha512-YdavWK6/8Cw6mypEgysGGX/dT9p9qnzFbnN5PQsUY+JJk2Nx8fKFydjGiQ+6rWPeW17RAv9mmbboh9uPVWxVlw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.259.0.tgz",
+      "integrity": "sha512-R0VTmNs+ySDDebU98BUbsLyeIM5YmAEr9esPpy15XfSy3AWmAeru8nLlztdaLilHZzLIDzvM2t7NGk/FzZFCvA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -689,14 +1762,14 @@
       }
     },
     "node_modules/@types/webidl-conversions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
-      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
     },
     "node_modules/@types/whatwg-url": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
-      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
@@ -1292,6 +2365,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1318,6 +2397,15 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/bson": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.0.tgz",
+      "integrity": "sha512-EL2KpZdyhshyyptj6pnQfnFKPoncD9KwZYvgmj/FXQiOUU1HWTHWmBOP4TZXU3YzStcI5qgpIl68YnMo16s26A==",
+      "peer": true,
+      "engines": {
+        "node": ">=14.20.1"
+      }
     },
     "node_modules/btoa": {
       "version": "1.2.1",
@@ -1716,6 +2804,57 @@
       "dependencies": {
         "archetype": "0.13.x",
         "mongodb": "4.x"
+      }
+    },
+    "node_modules/connect-mongodb-session/node_modules/bson": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/connect-mongodb-session/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/connect-mongodb-session/node_modules/mongodb": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
+      "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw==",
+      "dependencies": {
+        "bson": "^4.7.0",
+        "mongodb-connection-string-url": "^2.5.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "saslprep": "^1.0.3"
       }
     },
     "node_modules/consolidate": {
@@ -3108,6 +4247,22 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3679,9 +4834,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "node_modules/ip-regex": {
       "version": "2.1.0",
@@ -4627,71 +5782,45 @@
       "integrity": "sha1-+CzTcC/OiT0HPvVDaDmAyMBYjZA="
     },
     "node_modules/mongodb": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.3.1.tgz",
-      "integrity": "sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.0.0.tgz",
+      "integrity": "sha512-WHmlbefKp/iAX2LlSZ56iKt4pRftib/dD3mDaji8R7IJcRoKPc5+/kSn3mIBxKPLVxcl73KdDKBLkQTxj1OjaA==",
+      "peer": true,
       "dependencies": {
-        "bson": "^4.6.1",
-        "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.4.1",
-        "socks": "^2.6.1"
+        "bson": "^5.0.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=14.20.1"
       },
       "optionalDependencies": {
         "saslprep": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.201.0",
+        "mongodb-client-encryption": "^2.3.0",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.4.1.tgz",
-      "integrity": "sha512-d5Kd2bVsKcSA7YI/yo57fSTtMwRQdFkvc5IZwod1RRxJtECeWPPSo7zqcUGJELifRA//Igs4spVtYAmvFCatug==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
-      }
-    },
-    "node_modules/mongodb/node_modules/bson": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.1.tgz",
-      "integrity": "sha512-I1LQ7Hz5zgwR4QquilLNZwbhPw0Apx7i7X9kGMBTsqPdml/03Q9NBtD9nt/19ahjlphktQImrnderxqpzeVDjw==",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/mongodb/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/mongodb/node_modules/denque": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/mpath": {
@@ -6072,12 +7201,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "dependencies": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
       },
       "engines": {
         "node": ">= 10.13.0",
@@ -6296,6 +7425,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
+    },
     "node_modules/superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -6438,6 +7573,12 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -6885,6 +8026,918 @@
       "resolved": "https://registry.npmjs.org/@awaitjs/express/-/express-0.9.0.tgz",
       "integrity": "sha512-qzZEiDWgy0RBLHKPEkt9eHsh77YRJCkj5Mau/rP+Mwcte9F9iwPX+/Yy2+FABSpz8O2fu2Wr1DF/KNCieUa6eA==",
       "requires": {}
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.257.0.tgz",
+      "integrity": "sha512-ekWy391lOerS0ZECdhp/c+X7AToJIpfNrCPjuj3bKr+GMQYckGsYsdbm6AUD4sxBmfvuaQmVniSXWovaxwcFcQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.264.0.tgz",
+      "integrity": "sha512-afOpX6/xKLKRjkbgzfuy9fxCVP+LXCiirjBxhEtpUbKjVOwvShbQXfCPDlG40s5HF485mmR9t0KADoy0El5WsA==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.264.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-node": "3.264.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.264.0.tgz",
+      "integrity": "sha512-p+7sYpRcdv9omnnsPhD/vOFuZ1SpfV62ZgistBK/RDsQg2W9SIWQRW1KPt7gOCQ0nwp4efntw4Sle0LjS7ykxg==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.264.0.tgz",
+      "integrity": "sha512-82hGEbfsD4lBGIF1q8o82jTNSgBCcBpfFsvA+ltZf0bh4ChIWOi4vVvg8G+zVQN1mm/Rj8vWYO/D0tNF8OSyWw==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.264.0.tgz",
+      "integrity": "sha512-sco1jREkDdds4Z3V19Vlu/YpBHSzeEt1KFqOPnbjFw7pSakRNzpyWmLLxOwWjwgGKt6pSF3Aw0ZOMYsAUDc5qQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-node": "3.264.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-sdk-sts": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.259.0.tgz",
+      "integrity": "sha512-gViMRsc4Ye6+nzJ0OYTZIT8m4glIAdtugN2Sr/t6P2iJW5X0bSL/EcbcHBgsve1lHjeGPeyzVkT7UnyGOZ5Z/A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.264.0.tgz",
+      "integrity": "sha512-0L4offTpZJrX4PkoUI5KXPlG3uaofbmew+tgPphKd+ns3tzhLsltPMixS/04J5qXEfwMCHwvDgSpCenKsUo/wg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.264.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.257.0.tgz",
+      "integrity": "sha512-GsmBi5Di6hk1JAi1iB6/LCY8o+GmlCvJoB7wuoVmXI3VxRVwptUVjuj8EtJbIrVGrF9dSuIRPCzUoSuzEzYGlg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.259.0.tgz",
+      "integrity": "sha512-yCxoYWZAaDrCUEWxRfrpB0Mp1cFgJEMYW8T6GIb/+DQ5QLpZmorgaVD/j90QXupqFrR5tlxwuskBIkdD2E9YNg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.264.0.tgz",
+      "integrity": "sha512-UU5NNlfn+Go+5PLBzyTH1YE3r/pgykpE4QYFon87sCnEQnQH9xmlRTW1f1cBSQ9kivbFZd2/C2X3qhB3fe2JfA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.264.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.264.0.tgz",
+      "integrity": "sha512-DPzL7oawcILs5Mduim9Z8SVeJaUpaDRVbUIrBHsMBu+N7Zuqtzr+0ckHc1bEi3iYq2QUCk5pH5vpQaZYkMlbtw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/credential-provider-ini": "3.264.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.264.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.257.0.tgz",
+      "integrity": "sha512-xK8uYeNXaclaBCGrLi4z2pxPRngqLf5BM5jg2fn57zqvlL9V5gJF972FehrVBL0bfp1/laG0ZJtD2K2sapyWAw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.264.0.tgz",
+      "integrity": "sha512-CJuAlqIIJap6LXoqimvEAnYZ7Kb5pTbiS3e+aY+fajO3OPujmQpHuiY8kOmscjwZ4ErJdEskivcTGwXph0dPZQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.264.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/token-providers": "3.264.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.257.0.tgz",
+      "integrity": "sha512-Cm0uvRv4JuIbD0Kp3W0J/vwjADIyCx8HoZi5yg+QIi5nilocuTQ3ajvLeuPVSvFvdy+yaxSc5FxNXquWt7Mngw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.264.0.tgz",
+      "integrity": "sha512-4iSr1Z7Uf8uDraQ7JYoMotVLhmnGFAGsH559KBPxuxjMjg2lku9GA5V1zw7SNV8FEcj+Sh5HrpJvJ7P1kA+YjA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.264.0",
+        "@aws-sdk/client-sso": "3.264.0",
+        "@aws-sdk/client-sts": "3.264.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.264.0",
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/credential-provider-ini": "3.264.0",
+        "@aws-sdk/credential-provider-node": "3.264.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.264.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.257.0.tgz",
+      "integrity": "sha512-zOF+RzQ+wfF7tq7tGUdPcqUTh3+k2f8KCVJE07A8kCopVq4nBu4NH6Eq29Tjpwdya3YlKvE+kFssuQRRRRex+Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/querystring-builder": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.257.0.tgz",
+      "integrity": "sha512-W/USUuea5Ep3OJ2U7Ve8/5KN1YsDun2WzOFUxc1PyxXP5pW6OgC15/op0e+bmWPG851clvp5S8ZuroUr3aKi3Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.257.0.tgz",
+      "integrity": "sha512-T68SAPRNMEhpke0wlxURgogL7q0B8dfqZsSeS20BVR/lksJxLse9+pbmCDxiu1RrXoEIsEwl5rbLN+Hw8BFFYw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.257.0.tgz",
+      "integrity": "sha512-yiawbV2azm6QnMY1L2ypG8PDRdjOcEIvFmT0T7y0F49rfbKJOu21j1ONAoCkLrINK6kMqcD5JSQLVCoURxiTxQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.264.0.tgz",
+      "integrity": "sha512-H9JEAug3Oo3IA2wZIplVVF6NtauCIjICXWgbNbA8Im+I2KPe0jWtOdtQv4U+tqHe9T4zIixaCM3gjUBld+FoOA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.257.0.tgz",
+      "integrity": "sha512-gEi9AJdJfRfU8Qr6HK1hfhxTzyV3Giq4B/h7um99hIFAT/GCg9xiPvAOKPo6UeuiKEv3b7RpSL4s6cBvnJMJBA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.257.0.tgz",
+      "integrity": "sha512-8RDXW/VbMKBsXDfcCLmROZcWKyrekyiPa3J1aIaBy0tq9o4xpGoXw/lwwIrNVvISAFslb57rteup34bfn6ta6w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.257.0.tgz",
+      "integrity": "sha512-rUCih6zHh8k9Edf5N5Er4s508FYbwLM0MWTD2axzlj9TjLqEQ9OKED3wHaLffXSDzodd3oTAfJCLPbWQyoZ3ZQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.259.0.tgz",
+      "integrity": "sha512-pVh1g8e84MAi7eVtWLiiiCtn82LzxOP7+LxTRHatmgIeN22yGQBZILliPDJypUPvDYlwxI1ekiK+oPTcte0Uww==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/service-error-classification": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.257.0.tgz",
+      "integrity": "sha512-d6IJCLRi3O2tm4AFK60WNhIwmMmspj1WzKR1q1TaoPzoREPG2xg+Am18wZBRkCyYuRPPrbizmkvAmAJiUolMAw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.257.0.tgz",
+      "integrity": "sha512-/JasfXPWFq24mnCrx9fxW/ISBSp07RJwhsF14qzm8Qy3Z0z470C+QRM6otTwAkYuuVt1wuLjja5agq3Jtzq7dQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.257.0.tgz",
+      "integrity": "sha512-hCH3D83LHmm6nqmtNrGTWZCVjsQXrGHIXbd17/qrw7aPFvcAhsiiCncGFP+XsUXEKa2ZqcSNMUyPrx69ofNRZQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.257.0.tgz",
+      "integrity": "sha512-awg2F0SvwACBaw4HIObK8pQGfSqAc4Vy+YFzWSfZNVC35oRO6RsRdKHVU99lRC0LrT2Ptmfghl2DMPSrRDbvlQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.257.0.tgz",
+      "integrity": "sha512-37rt75LZyD0UWpbcFuxEGqwF3DZKSixQPl7AsDe6q3KtrO5gGQB+diH5vbY0txNNYyv5IK9WMwvY73mVmoWRmw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.259.0.tgz",
+      "integrity": "sha512-DUOqr71oonBvM6yKPdhDBmraqgXHCFrVWFw7hc5ZNxL2wS/EsbKfGPJp+C+SUgpn1upIWPNnh/bNoLAbBkcLsA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.257.0.tgz",
+      "integrity": "sha512-8KnWHVVwaGKyTlkTU9BSOAiSovNDoagxemU2l10QqBbzUCVpljCUMUkABEGRJ1yoQCl6DJ7RtNkAyZ8Ne/E15A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/abort-controller": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/querystring-builder": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.257.0.tgz",
+      "integrity": "sha512-3rUbRAcF0GZ5PhDiXhS4yREfZ5hOEtvYEa9S/19OdM5eoypOaLU5XnFcCKfnccSP8SkdgpJujzxOMRWNWadlAQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.257.0.tgz",
+      "integrity": "sha512-xt7LGOgZIvbLS3418AYQLacOqx+mo5j4mPiIMz7f6AaUg+/fBUgESVsncKDqxbEJVwwCXSka8Ca0cntJmoeMSw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.257.0.tgz",
+      "integrity": "sha512-mZHWLP7XIkzx1GIXO5WfX/iJ+aY9TWs02RE9FkdL2+by0HEMR65L3brQTbU1mIBJ7BjaPwYH24dljUOSABX7yg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.257.0.tgz",
+      "integrity": "sha512-UDrE1dEwWrWT8dG2VCrGYrPxCWOkZ1fPTPkjpkR4KZEdQDZBqU5gYZF2xPj8Nz7pjQVHFuW2wFm3XYEk56GEjg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.257.0.tgz",
+      "integrity": "sha512-FAyR0XsueGkkqDtkP03cTJQk52NdQ9sZelLynmmlGPUP75LApRPvFe1riKrou6+LsDbwVNVffj6mbDfIcOhaOw==",
+      "optional": true
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.257.0.tgz",
+      "integrity": "sha512-HNjC1+Wx3xHiJc+CP14GhIdVhfQGSjroAsWseRxAhONocA9Fl1ZX4hx7+sA5c9nOoMVOovi6ivJ/6lCRPTDRrQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.257.0.tgz",
+      "integrity": "sha512-aLQQN59X/D0+ShzPD3Anj5ntdMA/RFeNLOUCDyDvremViGi6yxUS98usQ/8bG5Rq0sW2GGMdbFUFmrDvqdiqEQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.261.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.261.0.tgz",
+      "integrity": "sha512-j8XQEa3caZUVFVZfhJjaskw80O/tB+IXu84HMN44N7UkXaCFHirUsNjTDztJhnVXf/gKXzIqUqprfRnOvwLtIg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.264.0.tgz",
+      "integrity": "sha512-1N54FCdBJRqrwFWHUoDpGI0rKhI29Or9ZwGjjcBzKzLhz5sEF/DEhuID7h1/KKEkXdQ0+lmXOFGMMrahrMpOow==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.264.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.257.0.tgz",
+      "integrity": "sha512-LmqXuBQBGeaGi/3Rp7XiEX1B5IPO2UUfBVvu0wwGqVsmstT0SbOVDZGPmxygACbm64n+PRx3uTSDefRfoiWYZg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.257.0.tgz",
+      "integrity": "sha512-Qe/AcFe/NFZHa6cN2afXEQn9ehXxh57dWGdRjfjd2lQqNV4WW1R2pl2Tm1ZJ1dwuCNLJi4NHLMk8lrD3QQ8rdg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.261.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.261.0.tgz",
+      "integrity": "sha512-lX3X1NfzQVV6cakepGV24uRcqevlDnQ8VgaCV8dhnw1FVThueFigyoFaUA02+uRXbV9KIbNWkEvweNtm2wvyDw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.261.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.261.0.tgz",
+      "integrity": "sha512-4AK6yu4bOmHSocUdbGoEHbNXB09UA58ON2HBHY4NxMBuFBAd9XB2tYiyhce+Cm+o+lHbS8oQnw0VZw16WMzzew==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.257.0.tgz",
+      "integrity": "sha512-3bvmRn5XGYzPPWjLuvHBKdJOb+fijnb8Ungu9bfXnTYFsng/ndHUWeHC22O/p8w3OWoRYUIMaZHxdxe27BFozg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.257.0.tgz",
+      "integrity": "sha512-F9ieon8B8eGVs5tyZtAIG3DZEObDvujkspho0qRbUTHUosM0ylJLsMU800fmC/uRHLRrZvb/RSp59+kNDwSAMw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-retry": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.257.0.tgz",
+      "integrity": "sha512-l9TOsOAYtZxwW3q5fQKW4rsD9t2HVaBfQ4zBamHkNTfB4vBVvCnz4oxkvSvA2MlxCA6am+K1K/oj917Tpqk53g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.257.0.tgz",
+      "integrity": "sha512-YdavWK6/8Cw6mypEgysGGX/dT9p9qnzFbnN5PQsUY+JJk2Nx8fKFydjGiQ+6rWPeW17RAv9mmbboh9uPVWxVlw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.259.0.tgz",
+      "integrity": "sha512-R0VTmNs+ySDDebU98BUbsLyeIM5YmAEr9esPpy15XfSy3AWmAeru8nLlztdaLilHZzLIDzvM2t7NGk/FzZFCvA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "@babel/code-frame": {
       "version": "7.14.5",
@@ -7374,14 +9427,14 @@
       }
     },
     "@types/webidl-conversions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
-      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
     },
     "@types/whatwg-url": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
-      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "requires": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
@@ -7853,6 +9906,12 @@
         }
       }
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -7876,6 +9935,12 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "bson": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.0.tgz",
+      "integrity": "sha512-EL2KpZdyhshyyptj6pnQfnFKPoncD9KwZYvgmj/FXQiOUU1HWTHWmBOP4TZXU3YzStcI5qgpIl68YnMo16s26A==",
+      "peer": true
     },
     "btoa": {
       "version": "1.2.1",
@@ -8071,6 +10136,918 @@
           "resolved": "https://registry.npmjs.org/@awaitjs/express/-/express-0.9.0.tgz",
           "integrity": "sha512-qzZEiDWgy0RBLHKPEkt9eHsh77YRJCkj5Mau/rP+Mwcte9F9iwPX+/Yy2+FABSpz8O2fu2Wr1DF/KNCieUa6eA==",
           "requires": {}
+        },
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "optional": true,
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "optional": true
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "optional": true,
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "optional": true
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "optional": true,
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "optional": true
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "optional": true,
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "optional": true
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "optional": true
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.257.0.tgz",
+          "integrity": "sha512-ekWy391lOerS0ZECdhp/c+X7AToJIpfNrCPjuj3bKr+GMQYckGsYsdbm6AUD4sxBmfvuaQmVniSXWovaxwcFcQ==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-cognito-identity": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.264.0.tgz",
+          "integrity": "sha512-afOpX6/xKLKRjkbgzfuy9fxCVP+LXCiirjBxhEtpUbKjVOwvShbQXfCPDlG40s5HF485mmR9t0KADoy0El5WsA==",
+          "optional": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/client-sts": "3.264.0",
+            "@aws-sdk/config-resolver": "3.259.0",
+            "@aws-sdk/credential-provider-node": "3.264.0",
+            "@aws-sdk/fetch-http-handler": "3.257.0",
+            "@aws-sdk/hash-node": "3.257.0",
+            "@aws-sdk/invalid-dependency": "3.257.0",
+            "@aws-sdk/middleware-content-length": "3.257.0",
+            "@aws-sdk/middleware-endpoint": "3.264.0",
+            "@aws-sdk/middleware-host-header": "3.257.0",
+            "@aws-sdk/middleware-logger": "3.257.0",
+            "@aws-sdk/middleware-recursion-detection": "3.257.0",
+            "@aws-sdk/middleware-retry": "3.259.0",
+            "@aws-sdk/middleware-serde": "3.257.0",
+            "@aws-sdk/middleware-signing": "3.257.0",
+            "@aws-sdk/middleware-stack": "3.257.0",
+            "@aws-sdk/middleware-user-agent": "3.257.0",
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/node-http-handler": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/smithy-client": "3.261.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/url-parser": "3.257.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+            "@aws-sdk/util-defaults-mode-node": "3.261.0",
+            "@aws-sdk/util-endpoints": "3.257.0",
+            "@aws-sdk/util-retry": "3.257.0",
+            "@aws-sdk/util-user-agent-browser": "3.257.0",
+            "@aws-sdk/util-user-agent-node": "3.259.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.264.0.tgz",
+          "integrity": "sha512-p+7sYpRcdv9omnnsPhD/vOFuZ1SpfV62ZgistBK/RDsQg2W9SIWQRW1KPt7gOCQ0nwp4efntw4Sle0LjS7ykxg==",
+          "optional": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.259.0",
+            "@aws-sdk/fetch-http-handler": "3.257.0",
+            "@aws-sdk/hash-node": "3.257.0",
+            "@aws-sdk/invalid-dependency": "3.257.0",
+            "@aws-sdk/middleware-content-length": "3.257.0",
+            "@aws-sdk/middleware-endpoint": "3.264.0",
+            "@aws-sdk/middleware-host-header": "3.257.0",
+            "@aws-sdk/middleware-logger": "3.257.0",
+            "@aws-sdk/middleware-recursion-detection": "3.257.0",
+            "@aws-sdk/middleware-retry": "3.259.0",
+            "@aws-sdk/middleware-serde": "3.257.0",
+            "@aws-sdk/middleware-stack": "3.257.0",
+            "@aws-sdk/middleware-user-agent": "3.257.0",
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/node-http-handler": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/smithy-client": "3.261.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/url-parser": "3.257.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+            "@aws-sdk/util-defaults-mode-node": "3.261.0",
+            "@aws-sdk/util-endpoints": "3.257.0",
+            "@aws-sdk/util-retry": "3.257.0",
+            "@aws-sdk/util-user-agent-browser": "3.257.0",
+            "@aws-sdk/util-user-agent-node": "3.259.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.264.0.tgz",
+          "integrity": "sha512-82hGEbfsD4lBGIF1q8o82jTNSgBCcBpfFsvA+ltZf0bh4ChIWOi4vVvg8G+zVQN1mm/Rj8vWYO/D0tNF8OSyWw==",
+          "optional": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.259.0",
+            "@aws-sdk/fetch-http-handler": "3.257.0",
+            "@aws-sdk/hash-node": "3.257.0",
+            "@aws-sdk/invalid-dependency": "3.257.0",
+            "@aws-sdk/middleware-content-length": "3.257.0",
+            "@aws-sdk/middleware-endpoint": "3.264.0",
+            "@aws-sdk/middleware-host-header": "3.257.0",
+            "@aws-sdk/middleware-logger": "3.257.0",
+            "@aws-sdk/middleware-recursion-detection": "3.257.0",
+            "@aws-sdk/middleware-retry": "3.259.0",
+            "@aws-sdk/middleware-serde": "3.257.0",
+            "@aws-sdk/middleware-stack": "3.257.0",
+            "@aws-sdk/middleware-user-agent": "3.257.0",
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/node-http-handler": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/smithy-client": "3.261.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/url-parser": "3.257.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+            "@aws-sdk/util-defaults-mode-node": "3.261.0",
+            "@aws-sdk/util-endpoints": "3.257.0",
+            "@aws-sdk/util-retry": "3.257.0",
+            "@aws-sdk/util-user-agent-browser": "3.257.0",
+            "@aws-sdk/util-user-agent-node": "3.259.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.264.0.tgz",
+          "integrity": "sha512-sco1jREkDdds4Z3V19Vlu/YpBHSzeEt1KFqOPnbjFw7pSakRNzpyWmLLxOwWjwgGKt6pSF3Aw0ZOMYsAUDc5qQ==",
+          "optional": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.259.0",
+            "@aws-sdk/credential-provider-node": "3.264.0",
+            "@aws-sdk/fetch-http-handler": "3.257.0",
+            "@aws-sdk/hash-node": "3.257.0",
+            "@aws-sdk/invalid-dependency": "3.257.0",
+            "@aws-sdk/middleware-content-length": "3.257.0",
+            "@aws-sdk/middleware-endpoint": "3.264.0",
+            "@aws-sdk/middleware-host-header": "3.257.0",
+            "@aws-sdk/middleware-logger": "3.257.0",
+            "@aws-sdk/middleware-recursion-detection": "3.257.0",
+            "@aws-sdk/middleware-retry": "3.259.0",
+            "@aws-sdk/middleware-sdk-sts": "3.257.0",
+            "@aws-sdk/middleware-serde": "3.257.0",
+            "@aws-sdk/middleware-signing": "3.257.0",
+            "@aws-sdk/middleware-stack": "3.257.0",
+            "@aws-sdk/middleware-user-agent": "3.257.0",
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/node-http-handler": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/smithy-client": "3.261.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/url-parser": "3.257.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+            "@aws-sdk/util-defaults-mode-node": "3.261.0",
+            "@aws-sdk/util-endpoints": "3.257.0",
+            "@aws-sdk/util-retry": "3.257.0",
+            "@aws-sdk/util-user-agent-browser": "3.257.0",
+            "@aws-sdk/util-user-agent-node": "3.259.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.259.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.259.0.tgz",
+          "integrity": "sha512-gViMRsc4Ye6+nzJ0OYTZIT8m4glIAdtugN2Sr/t6P2iJW5X0bSL/EcbcHBgsve1lHjeGPeyzVkT7UnyGOZ5Z/A==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/signature-v4": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-cognito-identity": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.264.0.tgz",
+          "integrity": "sha512-0L4offTpZJrX4PkoUI5KXPlG3uaofbmew+tgPphKd+ns3tzhLsltPMixS/04J5qXEfwMCHwvDgSpCenKsUo/wg==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/client-cognito-identity": "3.264.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.257.0.tgz",
+          "integrity": "sha512-GsmBi5Di6hk1JAi1iB6/LCY8o+GmlCvJoB7wuoVmXI3VxRVwptUVjuj8EtJbIrVGrF9dSuIRPCzUoSuzEzYGlg==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.259.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.259.0.tgz",
+          "integrity": "sha512-yCxoYWZAaDrCUEWxRfrpB0Mp1cFgJEMYW8T6GIb/+DQ5QLpZmorgaVD/j90QXupqFrR5tlxwuskBIkdD2E9YNg==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/url-parser": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.264.0.tgz",
+          "integrity": "sha512-UU5NNlfn+Go+5PLBzyTH1YE3r/pgykpE4QYFon87sCnEQnQH9xmlRTW1f1cBSQ9kivbFZd2/C2X3qhB3fe2JfA==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.257.0",
+            "@aws-sdk/credential-provider-imds": "3.259.0",
+            "@aws-sdk/credential-provider-process": "3.257.0",
+            "@aws-sdk/credential-provider-sso": "3.264.0",
+            "@aws-sdk/credential-provider-web-identity": "3.257.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.264.0.tgz",
+          "integrity": "sha512-DPzL7oawcILs5Mduim9Z8SVeJaUpaDRVbUIrBHsMBu+N7Zuqtzr+0ckHc1bEi3iYq2QUCk5pH5vpQaZYkMlbtw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.257.0",
+            "@aws-sdk/credential-provider-imds": "3.259.0",
+            "@aws-sdk/credential-provider-ini": "3.264.0",
+            "@aws-sdk/credential-provider-process": "3.257.0",
+            "@aws-sdk/credential-provider-sso": "3.264.0",
+            "@aws-sdk/credential-provider-web-identity": "3.257.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.257.0.tgz",
+          "integrity": "sha512-xK8uYeNXaclaBCGrLi4z2pxPRngqLf5BM5jg2fn57zqvlL9V5gJF972FehrVBL0bfp1/laG0ZJtD2K2sapyWAw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.264.0.tgz",
+          "integrity": "sha512-CJuAlqIIJap6LXoqimvEAnYZ7Kb5pTbiS3e+aY+fajO3OPujmQpHuiY8kOmscjwZ4ErJdEskivcTGwXph0dPZQ==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.264.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/token-providers": "3.264.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.257.0.tgz",
+          "integrity": "sha512-Cm0uvRv4JuIbD0Kp3W0J/vwjADIyCx8HoZi5yg+QIi5nilocuTQ3ajvLeuPVSvFvdy+yaxSc5FxNXquWt7Mngw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-providers": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.264.0.tgz",
+          "integrity": "sha512-4iSr1Z7Uf8uDraQ7JYoMotVLhmnGFAGsH559KBPxuxjMjg2lku9GA5V1zw7SNV8FEcj+Sh5HrpJvJ7P1kA+YjA==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/client-cognito-identity": "3.264.0",
+            "@aws-sdk/client-sso": "3.264.0",
+            "@aws-sdk/client-sts": "3.264.0",
+            "@aws-sdk/credential-provider-cognito-identity": "3.264.0",
+            "@aws-sdk/credential-provider-env": "3.257.0",
+            "@aws-sdk/credential-provider-imds": "3.259.0",
+            "@aws-sdk/credential-provider-ini": "3.264.0",
+            "@aws-sdk/credential-provider-node": "3.264.0",
+            "@aws-sdk/credential-provider-process": "3.257.0",
+            "@aws-sdk/credential-provider-sso": "3.264.0",
+            "@aws-sdk/credential-provider-web-identity": "3.257.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.257.0.tgz",
+          "integrity": "sha512-zOF+RzQ+wfF7tq7tGUdPcqUTh3+k2f8KCVJE07A8kCopVq4nBu4NH6Eq29Tjpwdya3YlKvE+kFssuQRRRRex+Q==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/querystring-builder": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.257.0.tgz",
+          "integrity": "sha512-W/USUuea5Ep3OJ2U7Ve8/5KN1YsDun2WzOFUxc1PyxXP5pW6OgC15/op0e+bmWPG851clvp5S8ZuroUr3aKi3Q==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.257.0.tgz",
+          "integrity": "sha512-T68SAPRNMEhpke0wlxURgogL7q0B8dfqZsSeS20BVR/lksJxLse9+pbmCDxiu1RrXoEIsEwl5rbLN+Hw8BFFYw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.257.0.tgz",
+          "integrity": "sha512-yiawbV2azm6QnMY1L2ypG8PDRdjOcEIvFmT0T7y0F49rfbKJOu21j1ONAoCkLrINK6kMqcD5JSQLVCoURxiTxQ==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.264.0.tgz",
+          "integrity": "sha512-H9JEAug3Oo3IA2wZIplVVF6NtauCIjICXWgbNbA8Im+I2KPe0jWtOdtQv4U+tqHe9T4zIixaCM3gjUBld+FoOA==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/signature-v4": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/url-parser": "3.257.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.257.0.tgz",
+          "integrity": "sha512-gEi9AJdJfRfU8Qr6HK1hfhxTzyV3Giq4B/h7um99hIFAT/GCg9xiPvAOKPo6UeuiKEv3b7RpSL4s6cBvnJMJBA==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.257.0.tgz",
+          "integrity": "sha512-8RDXW/VbMKBsXDfcCLmROZcWKyrekyiPa3J1aIaBy0tq9o4xpGoXw/lwwIrNVvISAFslb57rteup34bfn6ta6w==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.257.0.tgz",
+          "integrity": "sha512-rUCih6zHh8k9Edf5N5Er4s508FYbwLM0MWTD2axzlj9TjLqEQ9OKED3wHaLffXSDzodd3oTAfJCLPbWQyoZ3ZQ==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.259.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.259.0.tgz",
+          "integrity": "sha512-pVh1g8e84MAi7eVtWLiiiCtn82LzxOP7+LxTRHatmgIeN22yGQBZILliPDJypUPvDYlwxI1ekiK+oPTcte0Uww==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/service-error-classification": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/util-middleware": "3.257.0",
+            "@aws-sdk/util-retry": "3.257.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+              "optional": true
+            }
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.257.0.tgz",
+          "integrity": "sha512-d6IJCLRi3O2tm4AFK60WNhIwmMmspj1WzKR1q1TaoPzoREPG2xg+Am18wZBRkCyYuRPPrbizmkvAmAJiUolMAw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.257.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/signature-v4": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.257.0.tgz",
+          "integrity": "sha512-/JasfXPWFq24mnCrx9fxW/ISBSp07RJwhsF14qzm8Qy3Z0z470C+QRM6otTwAkYuuVt1wuLjja5agq3Jtzq7dQ==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.257.0.tgz",
+          "integrity": "sha512-hCH3D83LHmm6nqmtNrGTWZCVjsQXrGHIXbd17/qrw7aPFvcAhsiiCncGFP+XsUXEKa2ZqcSNMUyPrx69ofNRZQ==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/signature-v4": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/util-middleware": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.257.0.tgz",
+          "integrity": "sha512-awg2F0SvwACBaw4HIObK8pQGfSqAc4Vy+YFzWSfZNVC35oRO6RsRdKHVU99lRC0LrT2Ptmfghl2DMPSrRDbvlQ==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.257.0.tgz",
+          "integrity": "sha512-37rt75LZyD0UWpbcFuxEGqwF3DZKSixQPl7AsDe6q3KtrO5gGQB+diH5vbY0txNNYyv5IK9WMwvY73mVmoWRmw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.259.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.259.0.tgz",
+          "integrity": "sha512-DUOqr71oonBvM6yKPdhDBmraqgXHCFrVWFw7hc5ZNxL2wS/EsbKfGPJp+C+SUgpn1upIWPNnh/bNoLAbBkcLsA==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.257.0.tgz",
+          "integrity": "sha512-8KnWHVVwaGKyTlkTU9BSOAiSovNDoagxemU2l10QqBbzUCVpljCUMUkABEGRJ1yoQCl6DJ7RtNkAyZ8Ne/E15A==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/querystring-builder": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.257.0.tgz",
+          "integrity": "sha512-3rUbRAcF0GZ5PhDiXhS4yREfZ5hOEtvYEa9S/19OdM5eoypOaLU5XnFcCKfnccSP8SkdgpJujzxOMRWNWadlAQ==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.257.0.tgz",
+          "integrity": "sha512-xt7LGOgZIvbLS3418AYQLacOqx+mo5j4mPiIMz7f6AaUg+/fBUgESVsncKDqxbEJVwwCXSka8Ca0cntJmoeMSw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.257.0.tgz",
+          "integrity": "sha512-mZHWLP7XIkzx1GIXO5WfX/iJ+aY9TWs02RE9FkdL2+by0HEMR65L3brQTbU1mIBJ7BjaPwYH24dljUOSABX7yg==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.257.0.tgz",
+          "integrity": "sha512-UDrE1dEwWrWT8dG2VCrGYrPxCWOkZ1fPTPkjpkR4KZEdQDZBqU5gYZF2xPj8Nz7pjQVHFuW2wFm3XYEk56GEjg==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.257.0.tgz",
+          "integrity": "sha512-FAyR0XsueGkkqDtkP03cTJQk52NdQ9sZelLynmmlGPUP75LApRPvFe1riKrou6+LsDbwVNVffj6mbDfIcOhaOw==",
+          "optional": true
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.257.0.tgz",
+          "integrity": "sha512-HNjC1+Wx3xHiJc+CP14GhIdVhfQGSjroAsWseRxAhONocA9Fl1ZX4hx7+sA5c9nOoMVOovi6ivJ/6lCRPTDRrQ==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.257.0.tgz",
+          "integrity": "sha512-aLQQN59X/D0+ShzPD3Anj5ntdMA/RFeNLOUCDyDvremViGi6yxUS98usQ/8bG5Rq0sW2GGMdbFUFmrDvqdiqEQ==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.257.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.261.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.261.0.tgz",
+          "integrity": "sha512-j8XQEa3caZUVFVZfhJjaskw80O/tB+IXu84HMN44N7UkXaCFHirUsNjTDztJhnVXf/gKXzIqUqprfRnOvwLtIg==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.264.0.tgz",
+          "integrity": "sha512-1N54FCdBJRqrwFWHUoDpGI0rKhI29Or9ZwGjjcBzKzLhz5sEF/DEhuID7h1/KKEkXdQ0+lmXOFGMMrahrMpOow==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.264.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.257.0.tgz",
+          "integrity": "sha512-LmqXuBQBGeaGi/3Rp7XiEX1B5IPO2UUfBVvu0wwGqVsmstT0SbOVDZGPmxygACbm64n+PRx3uTSDefRfoiWYZg==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.257.0.tgz",
+          "integrity": "sha512-Qe/AcFe/NFZHa6cN2afXEQn9ehXxh57dWGdRjfjd2lQqNV4WW1R2pl2Tm1ZJ1dwuCNLJi4NHLMk8lrD3QQ8rdg==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-base64": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+          "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.261.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.261.0.tgz",
+          "integrity": "sha512-lX3X1NfzQVV6cakepGV24uRcqevlDnQ8VgaCV8dhnw1FVThueFigyoFaUA02+uRXbV9KIbNWkEvweNtm2wvyDw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.261.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.261.0.tgz",
+          "integrity": "sha512-4AK6yu4bOmHSocUdbGoEHbNXB09UA58ON2HBHY4NxMBuFBAd9XB2tYiyhce+Cm+o+lHbS8oQnw0VZw16WMzzew==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/config-resolver": "3.259.0",
+            "@aws-sdk/credential-provider-imds": "3.259.0",
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.257.0.tgz",
+          "integrity": "sha512-3bvmRn5XGYzPPWjLuvHBKdJOb+fijnb8Ungu9bfXnTYFsng/ndHUWeHC22O/p8w3OWoRYUIMaZHxdxe27BFozg==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+          "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.257.0.tgz",
+          "integrity": "sha512-F9ieon8B8eGVs5tyZtAIG3DZEObDvujkspho0qRbUTHUosM0ylJLsMU800fmC/uRHLRrZvb/RSp59+kNDwSAMw==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-retry": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.257.0.tgz",
+          "integrity": "sha512-l9TOsOAYtZxwW3q5fQKW4rsD9t2HVaBfQ4zBamHkNTfB4vBVvCnz4oxkvSvA2MlxCA6am+K1K/oj917Tpqk53g==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/service-error-classification": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.257.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.257.0.tgz",
+          "integrity": "sha512-YdavWK6/8Cw6mypEgysGGX/dT9p9qnzFbnN5PQsUY+JJk2Nx8fKFydjGiQ+6rWPeW17RAv9mmbboh9uPVWxVlw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/types": "3.257.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.259.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.259.0.tgz",
+          "integrity": "sha512-R0VTmNs+ySDDebU98BUbsLyeIM5YmAEr9esPpy15XfSy3AWmAeru8nLlztdaLilHZzLIDzvM2t7NGk/FzZFCvA==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+          "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+          "optional": true,
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.259.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+          "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+          "optional": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "@babel/code-frame": {
           "version": "7.14.5",
@@ -8560,14 +11537,14 @@
           }
         },
         "@types/webidl-conversions": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
-          "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
         },
         "@types/whatwg-url": {
-          "version": "8.2.1",
-          "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
-          "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+          "version": "8.2.2",
+          "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+          "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
           "requires": {
             "@types/node": "*",
             "@types/webidl-conversions": "*"
@@ -9039,6 +12016,12 @@
             }
           }
         },
+        "bowser": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+          "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+          "optional": true
+        },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -9062,6 +12045,12 @@
           "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
           "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
           "dev": true
+        },
+        "bson": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.0.tgz",
+          "integrity": "sha512-EL2KpZdyhshyyptj6pnQfnFKPoncD9KwZYvgmj/FXQiOUU1HWTHWmBOP4TZXU3YzStcI5qgpIl68YnMo16s26A==",
+          "peer": true
         },
         "btoa": {
           "version": "1.2.1",
@@ -9385,6 +12374,37 @@
           "requires": {
             "archetype": "0.13.x",
             "mongodb": "4.x"
+          },
+          "dependencies": {
+            "bson": {
+              "version": "4.7.2",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+              "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+              "requires": {
+                "buffer": "^5.6.0"
+              }
+            },
+            "buffer": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+              "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+              "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+              }
+            },
+            "mongodb": {
+              "version": "4.13.0",
+              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
+              "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw==",
+              "requires": {
+                "@aws-sdk/credential-providers": "^3.186.0",
+                "bson": "^4.7.0",
+                "mongodb-connection-string-url": "^2.5.4",
+                "saslprep": "^1.0.3",
+                "socks": "^2.7.1"
+              }
+            }
           }
         },
         "consolidate": {
@@ -10432,6 +13452,15 @@
             }
           }
         },
+        "fast-xml-parser": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+          "optional": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        },
         "file-entry-cache": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -10858,9 +13887,9 @@
           }
         },
         "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+          "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
         },
         "ip-regex": {
           "version": "2.1.0",
@@ -11556,45 +14585,21 @@
           "integrity": "sha1-+CzTcC/OiT0HPvVDaDmAyMBYjZA="
         },
         "mongodb": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.3.1.tgz",
-          "integrity": "sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.0.0.tgz",
+          "integrity": "sha512-WHmlbefKp/iAX2LlSZ56iKt4pRftib/dD3mDaji8R7IJcRoKPc5+/kSn3mIBxKPLVxcl73KdDKBLkQTxj1OjaA==",
+          "peer": true,
           "requires": {
-            "bson": "^4.6.1",
-            "denque": "^2.0.1",
-            "mongodb-connection-string-url": "^2.4.1",
+            "bson": "^5.0.0",
+            "mongodb-connection-string-url": "^2.6.0",
             "saslprep": "^1.0.3",
-            "socks": "^2.6.1"
-          },
-          "dependencies": {
-            "bson": {
-              "version": "4.6.1",
-              "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.1.tgz",
-              "integrity": "sha512-I1LQ7Hz5zgwR4QquilLNZwbhPw0Apx7i7X9kGMBTsqPdml/03Q9NBtD9nt/19ahjlphktQImrnderxqpzeVDjw==",
-              "requires": {
-                "buffer": "^5.6.0"
-              }
-            },
-            "buffer": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-              "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-              "requires": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-              }
-            },
-            "denque": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-              "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
-            }
+            "socks": "^2.7.1"
           }
         },
         "mongodb-connection-string-url": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.4.1.tgz",
-          "integrity": "sha512-d5Kd2bVsKcSA7YI/yo57fSTtMwRQdFkvc5IZwod1RRxJtECeWPPSo7zqcUGJELifRA//Igs4spVtYAmvFCatug==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+          "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
           "requires": {
             "@types/whatwg-url": "^8.2.1",
             "whatwg-url": "^11.0.0"
@@ -12644,12 +15649,12 @@
           "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
         },
         "socks": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-          "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+          "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
           "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "^4.1.0"
+            "ip": "^2.0.0",
+            "smart-buffer": "^4.2.0"
           }
         },
         "sonic-boom": {
@@ -12813,6 +15818,12 @@
             }
           }
         },
+        "strnum": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+          "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+          "optional": true
+        },
         "superagent": {
           "version": "3.8.3",
           "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -12925,6 +15936,12 @@
               }
             }
           }
+        },
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "optional": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
@@ -13476,6 +16493,37 @@
       "requires": {
         "archetype": "0.13.x",
         "mongodb": "4.x"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+          "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+          "requires": {
+            "buffer": "^5.6.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "mongodb": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
+          "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw==",
+          "requires": {
+            "@aws-sdk/credential-providers": "^3.186.0",
+            "bson": "^4.7.0",
+            "mongodb-connection-string-url": "^2.5.4",
+            "saslprep": "^1.0.3",
+            "socks": "^2.7.1"
+          }
+        }
       }
     },
     "consolidate": {
@@ -14523,6 +17571,15 @@
         }
       }
     },
+    "fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "optional": true,
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -14949,9 +18006,9 @@
       }
     },
     "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -15647,45 +18704,21 @@
       "integrity": "sha1-+CzTcC/OiT0HPvVDaDmAyMBYjZA="
     },
     "mongodb": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.3.1.tgz",
-      "integrity": "sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.0.0.tgz",
+      "integrity": "sha512-WHmlbefKp/iAX2LlSZ56iKt4pRftib/dD3mDaji8R7IJcRoKPc5+/kSn3mIBxKPLVxcl73KdDKBLkQTxj1OjaA==",
+      "peer": true,
       "requires": {
-        "bson": "^4.6.1",
-        "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.4.1",
+        "bson": "^5.0.0",
+        "mongodb-connection-string-url": "^2.6.0",
         "saslprep": "^1.0.3",
-        "socks": "^2.6.1"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.1.tgz",
-          "integrity": "sha512-I1LQ7Hz5zgwR4QquilLNZwbhPw0Apx7i7X9kGMBTsqPdml/03Q9NBtD9nt/19ahjlphktQImrnderxqpzeVDjw==",
-          "requires": {
-            "buffer": "^5.6.0"
-          }
-        },
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
-        "denque": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-          "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
-        }
+        "socks": "^2.7.1"
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.4.1.tgz",
-      "integrity": "sha512-d5Kd2bVsKcSA7YI/yo57fSTtMwRQdFkvc5IZwod1RRxJtECeWPPSo7zqcUGJELifRA//Igs4spVtYAmvFCatug==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "requires": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
@@ -16735,12 +19768,12 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "requires": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
       }
     },
     "sonic-boom": {
@@ -16904,6 +19937,12 @@
         }
       }
     },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
+    },
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -17016,6 +20055,12 @@
           }
         }
       }
+    },
+    "tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "body-parser": "^1.18.2",
     "debug": "^3.2.6",
     "express": "^4.16.4",
-    "mongodb": "^4.3.0"
+    "mongodb": "^5.0.0"
   },
   "dependencies": {
     "@awaitjs/express": "^0.9.0",

--- a/services/audit/services/journal.js
+++ b/services/audit/services/journal.js
@@ -39,7 +39,7 @@ module.exports.createAuditEntry = async function createAuditEntry(db, entry, opt
     }
 
     if (entry.user) {
-      entry.user = ObjectId(entry.user);
+      entry.user = new ObjectId(entry.user);
     }
 
     const res = await db

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -137,9 +137,9 @@ module.exports.signup = function (req, res) {
         });
     });
   };
-  const updateInvitedUser = function (user) {
-    return new Promise((resolve, reject) => {
-      users.findOneAndUpdate(
+  const updateInvitedUser = async function (user) {
+    try {
+      const result = await users.findOneAndUpdate(
         {
           email: user.email
         },
@@ -151,27 +151,20 @@ module.exports.signup = function (req, res) {
             updatedAt: new Date()
           }
         },
-        {
-          returnDocument: 'after'
-        },
-        (err, result) => {
-          return err ? reject(new Error('could not perform findOneAndUpdate')) : resolve(result.value);
-        }
+        { returnDocument: 'after' }
       );
-    });
+      return result.value;
+    } catch (err) {
+      throw new Error('could not perform findOneAndUpdate');
+    }
   };
 
-  const doesUserExist = function (user) {
-    return new Promise((resolve, reject) => {
-      users.findOne(
-        {
-          email: user.email
-        },
-        (err, result) => {
-          return err ? reject(new Error('could not perform findOneAndUpdate')) : resolve(result);
-        }
-      );
-    });
+  const doesUserExist = async function (user) {
+    try {
+      return await users.findOne({ email: user.email });
+    } catch (e) {
+      throw new Error('could not perform findOneAndUpdate');
+    }
   };
 
   if (req.body.email) {

--- a/services/auth/lib/middleware/authUser.js
+++ b/services/auth/lib/middleware/authUser.js
@@ -17,7 +17,7 @@ module.exports = function authUser(server) {
   // If the Authorization header contains a valid token
   // This strategy will return the associated user
   passport.use(
-    new BearerStrategy(function(token, done) {
+    new BearerStrategy(async function (token, done) {
       // users "tokens" property is an object
       // which have token as propertyName
       // and expiration date as value
@@ -25,12 +25,12 @@ module.exports = function authUser(server) {
       // expiration date is set in the future when the user signs in
       // it's easier and more elegant to check if the exp date is "later than now"
       query[`tokens.${token}.expiration`] = { $gt: new Date() };
-      users.findOne(query, (err, user) => {
-        if (err) {
-          debug('user findOne problem', query, err);
-        }
+      try {
+        const user = await users.findOne(query);
         return done(null, user, { scope: 'all' });
-      });
+      } catch (err) {
+        debug('user findOne problem', query, err);
+      }
     })
   );
 

--- a/services/auth/scripts/v2-migrate.js
+++ b/services/auth/scripts/v2-migrate.js
@@ -16,7 +16,7 @@ async function createEncryptedPassword(collection, salt, removeOldPassword, onCo
         if (removeOldPassword) {
           ops.$unset = { password: '' };
         }
-        return { filter: { _id: ObjectId(user._id) }, ops };
+        return { filter: { _id: new ObjectId(user._id) }, ops };
       })
     );
     updates = updates.filter(result => result.status === 'fulfilled').map(result => result.value);

--- a/services/docs/lib/modules/embedDocs.js
+++ b/services/docs/lib/modules/embedDocs.js
@@ -1,8 +1,8 @@
 /* eslint-disable node/no-unpublished-require */
-const async = require("async");
-const ObjectId = require("mongodb").ObjectId;
-const findReferences = require("../../../../lib/modules/findReferences");
-const createObjectId = require("campsi/lib/modules/createObjectId");
+const async = require('async');
+const ObjectId = require('mongodb').ObjectId;
+const findReferences = require('../../../../lib/modules/findReferences');
+const createObjectId = require('campsi/lib/modules/createObjectId');
 
 /**
  *
@@ -10,17 +10,9 @@ const createObjectId = require("campsi/lib/modules/createObjectId");
  * @param reference
  * @returns {Promise<unknown>}
  */
-function fetchDocument(resource, reference) {
-  return new Promise((resolve, reject) => {
-    resource.collection.findOne(
-      { _id: new ObjectId(reference) },
-      { _id: 1, states: 1 },
-      (err, document) => {
-        if (err) return reject(err);
-        return resolve(document?.states[resource.defaultState].data);
-      }
-    );
-  });
+async function fetchDocument(resource, reference) {
+  const document = await resource.collection.findOne({ _id: new ObjectId(reference) }, { _id: 1, states: 1 });
+  return document?.states[resource.defaultState].data;
 }
 
 /**
@@ -31,9 +23,9 @@ function fetchDocument(resource, reference) {
  * @returns {Promise<{}>}
  */
 function getSubDocument(resource, reference, fields) {
-  return fetchDocument(resource, reference).then((document) => {
+  return fetchDocument(resource, reference).then(document => {
     const subDocument = {};
-    fields.forEach((field) => {
+    fields.forEach(field => {
       subDocument[field] = document?.[field];
     });
     subDocument._id = new ObjectId(reference);
@@ -55,8 +47,7 @@ function embedDocs(resource, embed, user, doc, resources) {
     async.eachOf(
       resource.rels || {},
       (relationship, name, relationCb) => {
-        const embedRelation =
-          relationship.embed || (embed && embed.includes(name));
+        const embedRelation = relationship.embed || (embed && embed.includes(name));
         if (!embedRelation) {
           return async.setImmediate(relationCb);
         }
@@ -67,25 +58,17 @@ function embedDocs(resource, embed, user, doc, resources) {
           async.eachOf(
             references,
             (reference, index, referenceCb) => {
-              getSubDocument(
-                resources[relationship.resource],
-                reference,
-                relationship.fields || []
-              ).then((subDocument) => {
+              getSubDocument(resources[relationship.resource], reference, relationship.fields || []).then(subDocument => {
                 doc[name][index] = subDocument;
                 referenceCb();
               });
             },
-            (error) => {
+            error => {
               relationCb(error);
             }
           );
         } else if (createObjectId(references)) {
-          getSubDocument(
-            resources[relationship.resource],
-            references,
-            relationship.fields
-          ).then((subDocument) => {
+          getSubDocument(resources[relationship.resource], references, relationship.fields).then(subDocument => {
             doc[name] = subDocument;
             relationCb();
           });
@@ -100,11 +83,11 @@ function embedDocs(resource, embed, user, doc, resources) {
 
 module.exports.one = embedDocs;
 module.exports.many = function (resource, embed, user, docs, resources) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     async.forEach(
       docs,
       (doc, cb) => {
-        embedDocs(resource, embed, user, doc.data, resources).then((doc) => {
+        embedDocs(resource, embed, user, doc.data, resources).then(doc => {
           cb();
           return doc;
         });

--- a/services/docs/lib/modules/queryBuilder.js
+++ b/services/docs/lib/modules/queryBuilder.js
@@ -326,7 +326,7 @@ module.exports.setState = function setDocState(options) {
   const stateTo = getStateFromOptions(options, 'to');
 
   return new Promise((resolve, reject) => {
-    return validate(options.resource, options.doc, stateTo.validate)
+    return validate(options.resource, options.doc.states[options.from].data, stateTo.validate)
       .catch(reject)
       .then(() => {
         const ops = { $rename: {}, $set: {} };

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -254,7 +254,7 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
       $sort: sortCursor(
         null,
         sort,
-        (sort.startsWith('data') || sort.startsWith('-data')) ? 'states.{}.data.'.format(state) : '',
+        sort.startsWith('data') || sort.startsWith('-data') ? 'states.{}.data.'.format(state) : '',
         true
       )
     });
@@ -281,7 +281,7 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
           result.nav.next = info.page + 1;
         }
         if (sort && !aggregate) {
-          sortCursor(cursor, sort, (sort.startsWith('data') || sort.startsWith('-data')) ? 'states.{}.data.'.format(state) : '');
+          sortCursor(cursor, sort, sort.startsWith('data') || sort.startsWith('-data') ? 'states.{}.data.'.format(state) : '');
         }
         return cursor.toArray();
       })
@@ -352,7 +352,7 @@ module.exports.setDocument = async function (resource, filter, data, state, user
   const result = await resource.collection.updateOne(filter, update);
   // if document not found, must be a permissions issue
   if (result.modifiedCount !== 1) {
-    const doc = await resource.collection.findOne({ _id: ObjectId(filter._id) });
+    const doc = await resource.collection.findOne({ _id: new ObjectId(filter._id) });
     if (!doc) {
       throw new createError.NotFound('Not Found');
     }

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -8,6 +8,7 @@ const { ObjectId } = require('mongodb');
 
 const createError = require('http-errors');
 const { getDocumentLockServiceOptions } = require('../modules/serviceOptions');
+const { getUsersCollectionName } = require('../../../auth/lib/modules/collectionNames');
 
 // Helper functions
 const getDocUsersList = doc => Object.keys(doc ? doc.users : []).map(k => doc.users[k]);
@@ -251,7 +252,12 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
   if (sort) {
     pipeline.push({
       // eslint-disable-next-line indexof/no-indexof
-      $sort: sortCursor(null, sort, (sort.startsWith('data') || sort.startsWith('-data')) ? 'states.{}.data.'.format(state) : '', true)
+      $sort: sortCursor(
+        null,
+        sort,
+        sort.startsWith('data') || sort.startsWith('-data') ? 'states.{}.data.'.format(state) : '',
+        true
+      )
     });
   }
   const cursor = !aggregate
@@ -316,77 +322,50 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
   });
 };
 
-module.exports.createDocument = function (resource, data, state, user, parentId, groups) {
+module.exports.createDocument = async function (resource, data, state, user, parentId, groups) {
   removeVirtualProperties(resource, data);
-  return new Promise((resolve, reject) => {
-    builder
-      .create({
-        resource,
-        data,
-        state,
-        user,
-        parentId
-      })
-      .then(async doc => {
-        if (doc.parentId) {
-          try {
-            const parent = await resource.collection.findOne({
-              _id: doc.parentId
-            });
-            if (parent) {
-              doc.groups = parent.groups;
-            }
-          } catch (err) {}
-        }
+  const doc = await builder.create({ resource, data, state, user, parentId });
 
-        if (groups.length) {
-          doc.groups = [...new Set([...doc.groups, ...groups])];
-        }
+  if (doc.parentId) {
+    try {
+      const parent = await resource.collection.findOne({ _id: doc.parentId });
+      if (parent) {
+        doc.groups = parent.groups;
+      }
+    } catch (err) {}
+  }
 
-        resource.collection.insertOne(doc, (err, result) => {
-          if (err) return reject(err);
-          resolve({
-            state,
-            id: result.insertedId,
-            ...doc.states[state]
-          });
-        });
-      })
-      .catch(reject);
-  });
+  if (groups.length) {
+    doc.groups = [...new Set([...doc.groups, ...groups])];
+  }
+
+  const result = await resource.collection.insertOne(doc);
+  return {
+    state,
+    id: result.insertedId,
+    ...doc.states[state]
+  };
 };
 
-module.exports.setDocument = function (resource, filter, data, state, user) {
+module.exports.setDocument = async function (resource, filter, data, state, user) {
   removeVirtualProperties(resource, data);
-  return new Promise((resolve, reject) => {
-    builder
-      .update({
-        resource,
-        data,
-        state,
-        user
-      })
-      .then(update => {
-        resource.collection.updateOne(filter, update, (err, result) => {
-          if (err) return reject(err);
+  const update = await builder.update({ resource, data, state, user });
 
-          // if document not found, must be a permissions issue
-          if (result.modifiedCount !== 1) {
-            resource.collection.findOne({ _id: ObjectId(filter._id) }, {}, (_err, doc) => {
-              if (!doc) return reject(new createError.NotFound('Not Found'));
-              return reject(new createError.Unauthorized('Unauthorized'));
-            });
-          } else {
-            resolve({
-              id: filter._id,
-              state,
-              data
-            });
-          }
-        });
-      })
-      .catch(reject);
-  });
+  const result = await resource.collection.updateOne(filter, update);
+  // if document not found, must be a permissions issue
+  if (result.modifiedCount !== 1) {
+    const doc = await resource.collection.findOne({ _id: ObjectId(filter._id) });
+    if (!doc) {
+      throw new createError.NotFound('Not Found');
+    }
+    throw new createError.Unauthorized('Unauthorized');
+  } else {
+    return {
+      id: filter._id,
+      state,
+      data
+    };
+  }
 };
 
 module.exports.patchDocument = async (resource, filter, data, state, user) => {
@@ -471,35 +450,30 @@ module.exports.getDocumentLinks = function (resource, filter, query, _user, stat
   });
 };
 
-module.exports.getDocument = function (resource, filter, query, user, state, resources) {
+module.exports.getDocument = async function (resource, filter, query, user, state, resources) {
   const requestedStates = getRequestedStatesFromQuery(resource, query);
   const projection = { _id: 1, states: 1, users: 1, groups: 1 };
   const match = { ...filter };
   match[`states.${state}`] = { $exists: true };
 
   if (!resource.isInheritable) {
-    return new Promise((resolve, reject) => {
-      resource.collection.findOne(match, { projection }, (err, doc) => {
-        if (err) return reject(err);
-        if (doc === null) {
-          return reject(new Error('Document Not Found'));
-        }
-        if (doc.states[state] === undefined) {
-          return reject(new Error('Document Not Found'));
-        }
-        const returnValue = prepareGetDocument({
-          doc,
-          state,
-          permissions,
-          requestedStates,
-          resource,
-          user
-        });
-        embedDocs.one(resource, query.embed, user, returnValue.data, resources).then(_doc => {
-          resolve(returnValue);
-        });
-      });
+    const doc = await resource.collection.findOne(match, { projection });
+    if (!doc) {
+      throw new Error('Document Not Found');
+    }
+    if (!doc.states[state]) {
+      throw new Error('Document Not Found');
+    }
+    const returnValue = prepareGetDocument({
+      doc,
+      state,
+      permissions,
+      requestedStates,
+      resource,
+      user
     });
+    await embedDocs.one(resource, query.embed, user, returnValue.data, resources);
+    return returnValue;
   } else {
     const pipeline = [
       {
@@ -539,147 +513,105 @@ module.exports.getDocument = function (resource, filter, query, user, state, res
         }
       }
     ];
-    return new Promise((resolve, reject) => {
-      resource.collection
-        .aggregate(pipeline)
-        .toArray()
-        .then(documents => {
-          if (!documents || documents.length === 0) {
-            return reject(new Error('Document Not Found'));
-          }
-          const doc = documents[0];
-          const returnValue = prepareGetDocument({
-            doc,
-            state,
-            permissions,
-            requestedStates,
-            resource,
-            user
-          });
-          embedDocs.one(resource, query.embed, user, returnValue.data, resources).then(_doc => resolve(returnValue));
-        })
-        .catch(err => {
-          reject(err);
-        });
+    const documents = await resource.collection.aggregate(pipeline).toArray();
+    if (!documents.length) {
+      throw new Error('Document Not Found');
+    }
+    const doc = documents[0];
+    const returnValue = prepareGetDocument({
+      doc,
+      state,
+      permissions,
+      requestedStates,
+      resource,
+      user
     });
+    await embedDocs.one(resource, query.embed, user, returnValue.data, resources);
+    return returnValue;
   }
 };
 
-module.exports.getDocumentUsers = function (resource, filter) {
-  return new Promise((resolve, reject) => {
-    resource.collection.findOne(filter, { projection: { users: 1 } }, (err, doc) => {
-      if (err) {
-        return reject(err);
-      }
-      return resolve(getDocUsersList(doc));
-    });
-  });
+module.exports.getDocumentUsers = async function (resource, filter) {
+  const doc = await resource.collection.findOne(filter, { projection: { users: 1 } });
+  return getDocUsersList(doc);
 };
 
-module.exports.addUserToDocument = function (resource, filter, userDetails) {
-  return new Promise((resolve, reject) => {
-    resource.collection.findOne(filter, (err, document) => {
-      if (err || !document) return reject(err || 'Document is null');
-      const newUser = {
-        roles: userDetails.roles,
-        addedAt: new Date(),
-        userId: createObjectId(userDetails.userId) || userDetails.userId,
-        displayName: userDetails.displayName,
-        infos: userDetails.infos
-      };
-      const ops = {
-        $set: { [`users.${userDetails.userId}`]: newUser }
-      };
-      const options = { returnDocument: 'after', projection: { users: 1 } };
-      resource.collection.findOneAndUpdate(filter, ops, options, (err, result) => {
-        if (err) return reject(err);
-        if (!result.value) {
-          return reject(new Error('Not Found'));
-        }
-        resolve(getDocUsersList(result.value));
-      });
-    });
-  });
+module.exports.addUserToDocument = async function (resource, filter, userDetails) {
+  const document = await resource.collection.findOne(filter);
+  if (!document) {
+    throw new Error('Document is null');
+  }
+  const newUser = {
+    roles: userDetails.roles,
+    addedAt: new Date(),
+    userId: createObjectId(userDetails.userId) || userDetails.userId,
+    displayName: userDetails.displayName,
+    infos: userDetails.infos
+  };
+  const ops = {
+    $set: { [`users.${userDetails.userId}`]: newUser }
+  };
+  const options = { returnDocument: 'after', projection: { users: 1 } };
+  const result = await resource.collection.findOneAndUpdate(filter, ops, options);
+  if (!result.value) {
+    throw new Error('Not Found');
+  }
+  return getDocUsersList(result.value);
 };
 
-module.exports.removeUserFromDocument = function (resource, filter, userId, db) {
-  const removeUserFromDoc = new Promise((resolve, reject) => {
-    const ops = { $unset: { [`users.${userId}`]: 1 } };
-    const options = { returnDocument: 'after', projection: { users: 1 } };
-    resource.collection.findOneAndUpdate(filter, ops, options, (err, result) => {
-      if (err) return reject(err);
-      if (!result.value) {
-        return reject(new Error('Not Found'));
-      }
-      resolve(getDocUsersList(result.value));
-    });
-  });
+module.exports.removeUserFromDocument = async function (resource, filter, userId, db) {
   const groups = [`${resource.label}_${filter._id}`];
-  const removeGroupFromUser = new Promise((resolve, reject) => {
-    const filter = { _id: createObjectId(userId) };
-    const update = { $pull: { groups: { $in: groups } } };
-    db.collection('__users__').updateOne(filter, update, (err, _result) => {
-      if (err) return reject(err);
-      return resolve(null);
-    });
-  });
+  const [removeUserFromDoc, removeGroupFromUser] = await Promise.all([
+    resource.collection.findOneAndUpdate(
+      filter,
+      { $unset: { [`users.${userId}`]: 1 } },
+      { returnDocument: 'after', projection: { users: 1 } }
+    ),
+    db.collection(getUsersCollectionName()).updateOne({ _id: createObjectId(userId) }, { $pull: { groups: { $in: groups } } })
+  ]);
 
-  return Promise.all([removeUserFromDoc, removeGroupFromUser]).then(values => values[0]);
+  if (!removeUserFromDoc.value) {
+    throw new Error('Not Found');
+  }
+  return getDocUsersList(removeUserFromDoc.value);
 };
 
-module.exports.setDocumentState = function (resource, filter, fromState, toState, user) {
-  return new Promise((resolve, reject) => {
-    const doSetState = function (document) {
-      builder
-        .setState({
-          doc: document,
-          from: fromState,
-          to: toState,
-          resource,
-          user
-        })
-        .then(ops => {
-          resource.collection.updateOne(filter, ops, (err, result) => {
-            if (err) return reject(err);
+module.exports.setDocumentState = async function (resource, filter, fromState, toState, user) {
+  if (!resource.states[toState]) {
+    throw new Error(`Undefined state: ${toState}`);
+  }
 
-            if (result.modifiedCount !== 1) {
-              return reject(new Error('Not Found'));
-            }
+  if (!resource.states[fromState]) {
+    throw new Error(`Undefined state: ${fromState}`);
+  }
 
-            resolve({
-              doc: document,
-              state: {
-                from: fromState,
-                to: toState
-              }
-            });
-          });
-        })
-        .catch(reject);
-    };
+  const doc = await resource.collection.findOne(filter);
 
-    const stateTo = resource.states[toState];
-    const stateFrom = resource.states[fromState];
+  const allowedPutStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'PUT', doc);
+  const allowedGetStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'GET', doc);
 
-    if (typeof stateTo === 'undefined') {
-      reject(new Error(`Undefined state: ${toState}`));
-    }
-
-    if (typeof stateFrom === 'undefined') {
-      reject(new Error(`Undefined state: ${fromState}`));
-    }
-
-    resource.collection.findOne(filter, (err, document) => {
-      if (err) return reject(err);
-      const allowedPutStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'PUT', document);
-      const allowedGetStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'GET', document);
-      if (allowedPutStates.includes(toState) && allowedGetStates.includes(fromState)) {
-        doSetState(document.states[fromState].data);
-      } else {
-        reject(new Error('Unauthorized'));
-      }
+  if (allowedPutStates.includes(toState) && allowedGetStates.includes(fromState)) {
+    const ops = await builder.setState({
+      doc,
+      from: fromState,
+      to: toState,
+      resource,
+      user
     });
-  });
+    const result = await resource.collection.updateOne(filter, ops);
+    if (result.modifiedCount !== 1) {
+      throw new Error('Not Found');
+    }
+    return {
+      doc,
+      state: {
+        from: fromState,
+        to: toState
+      }
+    };
+  } else {
+    throw new Error('Unauthorized');
+  }
 };
 
 module.exports.deleteDocument = function (resource, filter) {
@@ -746,7 +678,7 @@ const prepareGetDocument = settings => {
     data: currentState.data || {},
     groups: doc.groups || [],
     states: permissions.filterDocumentStates(doc, allowedStates, requestedStates)
-  }
+  };
 
   if (doc.metadata) {
     result.metadata = doc.metadata;

--- a/services/docs/scripts/migrate_owner_to_users.js
+++ b/services/docs/scripts/migrate_owner_to_users.js
@@ -14,8 +14,7 @@ if (!module.parent) {
     return collections.concat(resourcesNames.map(resourceName => `docs.${service}.${resourceName}`));
   }, []);
   const mongoUri = config.campsi.mongo.uri;
-  MongoClient.connect(mongoUri, (err, client) => {
-    if (err) throw err;
+  MongoClient.connect(mongoUri).then(client => {
     const db = client.db(config.campsi.mongo.database);
     migrate(options.params, db, collections);
   });
@@ -43,57 +42,50 @@ async function updateCollection(params, db, collection, done) {
     filter.users = { $exists: false };
   }
   try {
-    const cursor = await db.collection(collection).find(filter, { projection: { ownedBy: 1, _id: 1 } });
-    let cursorHasNext = true;
-    const updateDocument = (doc, cb) => {
-      if (doc === null) {
-        debug('document is null');
-        return cb();
-      }
-      const ops = {
-        $set: {
-          users: { [doc.ownedBy]: { roles: ['owner'], userId: doc.ownedBy } }
-        }
-      };
-      if (params.includes('--remove-ownedBy')) {
-        ops.$unset = { ownedBy: 1 };
-      }
-      db.collection(collection).updateOne({ _id: doc._id }, ops, (err, result) => {
-        err ? debug('an error occured during the update', err) : debug(collection, doc._id, 'nModified', result.modifiedCount);
-        cursor.hasNext((err, hasNext) => {
-          /* istanbul ignore if  */
-          if (err) debug('error occured while fetching hasNext() information', err);
-          cursorHasNext = hasNext;
-          cb();
-        });
-      });
-    };
-    cursor.hasNext((err, hasNext) => {
-      /* istanbul ignore if  */
-      if (err) {
-        debug('error occured while fetching hasNext() information', err);
-        return done();
-      }
-      cursorHasNext = hasNext;
+    const cursor = await db
+      .collection(collection)
+      .find(filter, { projection: { ownedBy: 1, _id: 1 } })
+      .toArray();
+
+    try {
+      let cursorHasNext = await cursor.hasNext();
       if (!cursorHasNext) {
         debug(collection, 'has no element');
       }
-      async.whilst(
-        () => cursorHasNext,
-        cb => {
-          cursor.next((err, doc) => {
-            /* istanbul ignore if  */
-            if (err) {
-              debug('error occured while fetching next() element', err);
-              cursorHasNext = false;
-              return cb();
+      while (cursorHasNext) {
+        // update document
+        try {
+          const doc = await cursor.next();
+          if (!doc === null) {
+            debug('document is null');
+            cursorHasNext = false;
+          }
+          const ops = {
+            $set: {
+              users: {
+                [doc.ownedBy]: {
+                  roles: ['owner'],
+                  userId: doc.ownedBy
+                }
+              }
             }
-            updateDocument(doc, cb);
-          });
-        },
-        done
-      );
-    });
+          };
+          if (params.includes('--remove-ownedBy')) {
+            ops.$unset = { ownedBy: 1 };
+          }
+
+          const result = await db.collection(collection).updateOne({ _id: doc._id }, ops);
+          debug(collection, doc._id, 'nModified', result.modifiedCount);
+          cursorHasNext = await cursor.hasNext();
+        } catch (err) {
+          debug('error occured while fetching next() element', err);
+          cursorHasNext = false;
+        }
+      }
+    } catch (err) {
+      debug('error occured while fetching hasNext() information', err);
+    }
+    return done();
   } catch (err) {
     return debug(`an error occured during the find() from collection ${collection}`, err);
   }

--- a/services/docs/scripts/migrate_owner_to_users.js
+++ b/services/docs/scripts/migrate_owner_to_users.js
@@ -24,7 +24,7 @@ async function migrate(params, db, collections, done) {
     debug('migrate collection', collection);
     await updateCollection(params, db, collection);
   }
-  return debug('migration complete');
+  debug('migration complete');
 }
 
 async function updateCollection(params, db, collection) {

--- a/services/webhooks/lib/index.js
+++ b/services/webhooks/lib/index.js
@@ -73,7 +73,7 @@ class WebhooksService extends CampsiService {
 
   getWebhooks(req, res) {
     this.collection
-      .find(this.options.requireAuth ? { createdBy: ObjectId(req.user._id) } : {})
+      .find(this.options.requireAuth ? { createdBy: new ObjectId(req.user._id) } : {})
       .toArray()
       .then(webhooks => {
         res.json({ webhooks });
@@ -93,7 +93,7 @@ class WebhooksService extends CampsiService {
       failCount: 0
     };
     if (this.options.requireAuth) {
-      doc.createdBy = ObjectId(req.user._id);
+      doc.createdBy = new ObjectId(req.user._id);
     }
     this.collection
       .insertOne(doc)
@@ -110,7 +110,7 @@ class WebhooksService extends CampsiService {
       _id: ObjectId(req.params.id)
     };
     if (this.options.requireAuth) {
-      filter.createdBy = ObjectId(req.user._id);
+      filter.createdBy = new ObjectId(req.user._id);
     }
     this.collection
       .deleteOne(filter)

--- a/test/audit/service_creation.js
+++ b/test/audit/service_creation.js
@@ -45,9 +45,9 @@ describe('Audit Service', () => {
       res.should.be.json;
 
       // check it is in the db
-      const logEntry = await context.campsi.db.collection('audit').findOne({ user: ObjectId(entry.user) });
+      const logEntry = await context.campsi.db.collection('audit').findOne({ user: new ObjectId(entry.user) });
 
-      const theSame = logEntry.user.equals(ObjectId(entry.user));
+      const theSame = logEntry.user.equals(new ObjectId(entry.user));
 
       theSame.should.be.true;
     });
@@ -111,9 +111,9 @@ describe('Audit Service', () => {
       await auditService.createLog(entry);
 
       // check it is in the db
-      const logEntry = await context.campsi.db.collection('audit').findOne({ user: ObjectId(entry.user) });
+      const logEntry = await context.campsi.db.collection('audit').findOne({ user: new ObjectId(entry.user) });
 
-      const theSame = logEntry.user.equals(ObjectId(entry.user));
+      const theSame = logEntry.user.equals(new ObjectId(entry.user));
 
       theSame.should.be.true;
     });

--- a/test/auth/auth-docs.js
+++ b/test/auth/auth-docs.js
@@ -51,8 +51,8 @@ function createUser(campsi, user) {
 
 describe('Auth Local API', async () => {
   const context = {};
-  beforeEach(async () => await setupBeforeEach(config, services, context));
-  afterEach(async () => await context.server.close());
+  beforeEach(setupBeforeEach(config, services, context));
+  afterEach(context.server.close());
 
   describe('/PUT docs as a user', async () => {
     it('it should create 2 users and try to update a doc and get the correct status code', async () => {

--- a/test/auth/auth-docs.js
+++ b/test/auth/auth-docs.js
@@ -51,8 +51,8 @@ function createUser(campsi, user) {
 
 describe('Auth Local API', async () => {
   const context = {};
-  beforeEach(setupBeforeEach(config, services, context));
-  afterEach(done => context.server.close(done));
+  beforeEach(async () => await setupBeforeEach(config, services, context));
+  afterEach(async () => await context.server.close());
 
   describe('/PUT docs as a user', async () => {
     it('it should create 2 users and try to update a doc and get the correct status code', async () => {

--- a/test/auth/auth.js
+++ b/test/auth/auth.js
@@ -574,7 +574,7 @@ describe('Auth API', () => {
       });
     });
 
-    it('should not create a new user', done => {
+    it('should not create a new user', async done => {
       const campsi = context.campsi;
       const robert = {
         displayName: 'Robert Bennett',
@@ -582,31 +582,31 @@ describe('Auth API', () => {
         username: 'robert',
         password: 'signup!'
       };
-      createUser(chai, campsi, robert)
-        .then(createUser(chai, campsi, glenda, true))
-        .then(token => {
-          chai
-            .request(campsi.app)
-            .post('/auth/invitations')
-            .set('content-type', 'application/json')
-            .set('Authorization', 'Bearer ' + token)
-            .send({
-              email: 'robert@agilitation.fr'
-            })
-            .end((err, res) => {
-              if (err) debug(`received an error from chai: ${err.message}`);
-              res.should.have.status(200);
-              res.should.be.json;
-              res.should.be.a('object');
-              res.body.should.have.property('id');
-              debug(res.body);
-              campsi.db.collection(getUsersCollectionName()).findOne({ email: robert.email }, (err, doc) => {
-                if (err) return debug(`received an error from chai: ${err.message}`);
-                doc.should.be.a('object');
-                res.body.id.should.be.eq(doc._id.toString());
-                done();
-              });
-            });
+      await createUser(chai, campsi, robert);
+      const token = createUser(chai, campsi, glenda, true);
+      chai
+        .request(campsi.app)
+        .post('/auth/invitations')
+        .set('content-type', 'application/json')
+        .set('Authorization', 'Bearer ' + token)
+        .send({
+          email: 'robert@agilitation.fr'
+        })
+        .end(async (err, res) => {
+          if (err) debug(`received an error from chai: ${err.message}`);
+          res.should.have.status(200);
+          res.should.be.json;
+          res.should.be.a('object');
+          res.body.should.have.property('id');
+          debug(res.body);
+          try {
+            const doc = await campsi.db.collection(getUsersCollectionName()).findOne({ email: robert.email });
+            doc.should.be.a('object');
+            res.body.id.should.be.eq(doc._id.toString());
+            done();
+          } catch (e) {
+            return debug(`received an error from chai: ${err.message}`);
+          }
         });
     });
     it('should allow someone else to use the invitation', async () => {

--- a/test/auth/collection-name-default.js
+++ b/test/auth/collection-name-default.js
@@ -13,6 +13,7 @@ const chaiHttp = require('chai-http');
 const format = require('string-format');
 const { getUsersCollectionName, getSessionCollectionName } = require('../../services/auth/lib/modules/collectionNames');
 const AuthService = require('../../services/auth/lib');
+const { emptyDatabase } = require('../helpers/emptyDatabase');
 const expect = chai.expect;
 format.extend(String.prototype);
 chai.use(chaiHttp);
@@ -20,24 +21,18 @@ chai.should();
 
 describe('Auth API', () => {
   const context = {};
-  beforeEach(done => {
-    const mongoUri = mongoUriBuilder(config.campsi.mongo);
-    MongoClient.connect(mongoUri, (err, client) => {
-      if (err) throw err;
-      const db = client.db(config.campsi.mongo.database);
-      db.dropDatabase(() => {
-        client.close();
-        context.campsi = new CampsiServer(config.campsi);
-        context.campsi.mount('auth', new AuthService(config.services.auth));
+  beforeEach(async done => {
+    await emptyDatabase(config);
 
-        context.campsi.on('campsi/ready', () => {
-          context.server = context.campsi.listen(config.port);
-          done();
-        });
-        context.campsi.start().catch(err => {
-          debug('Error: %s', err);
-        });
-      });
+    context.campsi = new CampsiServer(config.campsi);
+    context.campsi.mount('auth', new AuthService(config.services.auth));
+
+    context.campsi.on('campsi/ready', () => {
+      context.server = context.campsi.listen(config.port);
+      done();
+    });
+    context.campsi.start().catch(err => {
+      debug('Error: %s', err);
     });
   });
 

--- a/test/auth/collection-name-default.js
+++ b/test/auth/collection-name-default.js
@@ -21,18 +21,18 @@ chai.should();
 
 describe('Auth API', () => {
   const context = {};
-  beforeEach(async done => {
-    await emptyDatabase(config);
+  beforeEach(done => {
+    emptyDatabase(config).then(() => {
+      context.campsi = new CampsiServer(config.campsi);
+      context.campsi.mount('auth', new AuthService(config.services.auth));
 
-    context.campsi = new CampsiServer(config.campsi);
-    context.campsi.mount('auth', new AuthService(config.services.auth));
-
-    context.campsi.on('campsi/ready', () => {
-      context.server = context.campsi.listen(config.port);
-      done();
-    });
-    context.campsi.start().catch(err => {
-      debug('Error: %s', err);
+      context.campsi.on('campsi/ready', () => {
+        context.server = context.campsi.listen(config.port);
+        done();
+      });
+      context.campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 

--- a/test/auth/collection-name.js
+++ b/test/auth/collection-name.js
@@ -24,18 +24,18 @@ chai.should();
 
 describe('Auth API', () => {
   const context = {};
-  beforeEach(async done => {
-    await emptyDatabase(config);
+  beforeEach(done => {
+    emptyDatabase(config).then(() => {
+      context.campsi = new CampsiServer(config.campsi);
+      context.campsi.mount('auth', new AuthService(config.services.auth));
 
-    context.campsi = new CampsiServer(config.campsi);
-    context.campsi.mount('auth', new AuthService(config.services.auth));
-
-    context.campsi.on('campsi/ready', () => {
-      context.server = context.campsi.listen(config.port);
-      done();
-    });
-    context.campsi.start().catch(err => {
-      debug('Error: %s', err);
+      context.campsi.on('campsi/ready', () => {
+        context.server = context.campsi.listen(config.port);
+        done();
+      });
+      context.campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 

--- a/test/auth/collection-name.js
+++ b/test/auth/collection-name.js
@@ -16,6 +16,7 @@ const chaiHttp = require('chai-http');
 const format = require('string-format');
 const { getUsersCollectionName, getSessionCollectionName } = require('../../services/auth/lib/modules/collectionNames');
 const AuthService = require('../../services/auth/lib');
+const { emptyDatabase } = require('../helpers/emptyDatabase');
 const expect = chai.expect;
 format.extend(String.prototype);
 chai.use(chaiHttp);
@@ -23,24 +24,18 @@ chai.should();
 
 describe('Auth API', () => {
   const context = {};
-  beforeEach(done => {
-    const mongoUri = mongoUriBuilder(config.campsi.mongo);
-    MongoClient.connect(mongoUri, (err, client) => {
-      if (err) throw err;
-      const db = client.db(config.campsi.mongo.database);
-      db.dropDatabase(() => {
-        client.close();
-        context.campsi = new CampsiServer(config.campsi);
-        context.campsi.mount('auth', new AuthService(config.services.auth));
+  beforeEach(async done => {
+    await emptyDatabase(config);
 
-        context.campsi.on('campsi/ready', () => {
-          context.server = context.campsi.listen(config.port);
-          done();
-        });
-        context.campsi.start().catch(err => {
-          debug('Error: %s', err);
-        });
-      });
+    context.campsi = new CampsiServer(config.campsi);
+    context.campsi.mount('auth', new AuthService(config.services.auth));
+
+    context.campsi.on('campsi/ready', () => {
+      context.server = context.campsi.listen(config.port);
+      done();
+    });
+    context.campsi.start().catch(err => {
+      debug('Error: %s', err);
     });
   });
 

--- a/test/docs/crud.js
+++ b/test/docs/crud.js
@@ -34,19 +34,19 @@ async function createPizza(data, state) {
 
 // Our parent block
 describe('CRUD', () => {
-  beforeEach(async done => {
-    await emptyDatabase(config);
+  beforeEach(done => {
+    emptyDatabase(config).then(() => {
+      campsi = new CampsiServer(config.campsi);
 
-    campsi = new CampsiServer(config.campsi);
+      campsi.mount('docs', new services.Docs(config.services.docs));
 
-    campsi.mount('docs', new services.Docs(config.services.docs));
-
-    campsi.on('campsi/ready', () => {
-      server = campsi.listen(config.port);
-      done();
-    });
-    campsi.start().catch(err => {
-      debug('Error: %s', err);
+      campsi.on('campsi/ready', () => {
+        server = campsi.listen(config.port);
+        done();
+      });
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 

--- a/test/docs/document-links.js
+++ b/test/docs/document-links.js
@@ -163,19 +163,19 @@ function getPizzaWithoutLinksInHeader(id) {
 
 // Our parent block
 describe('Document links', async () => {
-  before(async done => {
-    await emptyDatabase(config);
+  before(done => {
+    emptyDatabase(config).then(() => {
+      campsi = new CampsiServer(config.campsi);
+      campsi.mount('docs', new services.Docs(config.services.docs));
 
-    campsi = new CampsiServer(config.campsi);
-    campsi.mount('docs', new services.Docs(config.services.docs));
+      campsi.on('campsi/ready', () => {
+        server = campsi.listen(config.port);
+        done();
+      });
 
-    campsi.on('campsi/ready', () => {
-      server = campsi.listen(config.port);
-      done();
-    });
-
-    campsi.start().catch(err => {
-      debug('Error: %s', err);
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 

--- a/test/docs/document-links.js
+++ b/test/docs/document-links.js
@@ -14,6 +14,7 @@ const config = require('config');
 const builder = require('../../services/docs/lib/modules/queryBuilder');
 const fakeId = require('fake-object-id');
 const { ObjectId } = require('mongodb');
+const { emptyDatabase } = require('../helpers/emptyDatabase');
 
 chai.should();
 let campsi;
@@ -49,25 +50,10 @@ function deletePizza(pizzaId) {
   const resource = campsi.services.get('docs').options.resources.pizzas;
   return resource.collection.deleteOne(filter);
 }
-function buildPizzaDoc(data, resource, state) {
-  return new Promise(function (resolve, reject) {
-    builder
-      .create({
-        user: owner,
-        data,
-        resource,
-        state
-      })
-      .then(doc => {
-        resource.collection.insertOne(doc, (err, result) => {
-          if (err) return reject(err);
-          resolve(result.insertedId);
-        });
-      })
-      .catch(error => {
-        reject(error);
-      });
-  });
+async function buildPizzaDoc(data, resource, state) {
+  const doc = await builder.create({ user: owner, data, resource, state });
+  const result = await resource.collection.insertOne(doc);
+  return result.insertedId;
 }
 
 // Helpers
@@ -177,26 +163,19 @@ function getPizzaWithoutLinksInHeader(id) {
 
 // Our parent block
 describe('Document links', async () => {
-  before(done => {
-    // Empty the database
-    const mongoUri = mongoUriBuilder(config.campsi.mongo);
-    MongoClient.connect(mongoUri, (err, client) => {
-      if (err) throw err;
-      const db = client.db(config.campsi.mongo.database);
-      db.dropDatabase(() => {
-        client.close();
-        campsi = new CampsiServer(config.campsi);
-        campsi.mount('docs', new services.Docs(config.services.docs));
+  before(async done => {
+    await emptyDatabase(config);
 
-        campsi.on('campsi/ready', () => {
-          server = campsi.listen(config.port);
-          done();
-        });
+    campsi = new CampsiServer(config.campsi);
+    campsi.mount('docs', new services.Docs(config.services.docs));
 
-        campsi.start().catch(err => {
-          debug('Error: %s', err);
-        });
-      });
+    campsi.on('campsi/ready', () => {
+      server = campsi.listen(config.port);
+      done();
+    });
+
+    campsi.start().catch(err => {
+      debug('Error: %s', err);
     });
   });
 

--- a/test/docs/embed.js
+++ b/test/docs/embed.js
@@ -85,22 +85,22 @@ async function createEmptyArticle(title) {
 
 // Our parent block
 describe('Embedded Documents', () => {
-  beforeEach(async done => {
-    await emptyDatabase(config);
+  beforeEach(done => {
+    emptyDatabase(config).then(() => {
+      campsi = new CampsiServer(config.campsi);
+      campsi.mount('docs', new services.Docs(config.services.docs));
+      campsi.app.use((req, res, next) => {
+        req.user = owner;
+        next();
+      });
 
-    campsi = new CampsiServer(config.campsi);
-    campsi.mount('docs', new services.Docs(config.services.docs));
-    campsi.app.use((req, res, next) => {
-      req.user = owner;
-      next();
-    });
-
-    campsi.on('campsi/ready', () => {
-      server = campsi.listen(config.port);
-      done();
-    });
-    campsi.start().catch(err => {
-      debug('Error: %s', err);
+      campsi.on('campsi/ready', () => {
+        server = campsi.listen(config.port);
+        done();
+      });
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 

--- a/test/docs/events.js
+++ b/test/docs/events.js
@@ -26,23 +26,23 @@ const me = { _id: 'me' };
 
 // Our parent block
 describe('Events', () => {
-  beforeEach(async done => {
-    await emptyDatabase(config);
+  beforeEach(done => {
+    emptyDatabase(config).then(() => {
+      campsi = new CampsiServer(config.campsi);
+      campsi.mount('docs', new services.Docs(config.services.docs));
+      campsi.app.use((req, res, next) => {
+        req.user = me;
+        next();
+      });
 
-    campsi = new CampsiServer(config.campsi);
-    campsi.mount('docs', new services.Docs(config.services.docs));
-    campsi.app.use((req, res, next) => {
-      req.user = me;
-      next();
-    });
+      campsi.on('campsi/ready', () => {
+        server = campsi.listen(config.port);
+        done();
+      });
 
-    campsi.on('campsi/ready', () => {
-      server = campsi.listen(config.port);
-      done();
-    });
-
-    campsi.start().catch(err => {
-      debug('Error: %s', err);
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 

--- a/test/docs/filters.js
+++ b/test/docs/filters.js
@@ -58,22 +58,22 @@ function testDocument(document, index) {
 
 // Our parent block
 describe('Filter Documents', () => {
-  beforeEach(async done => {
-    await emptyDatabase(config);
+  beforeEach(done => {
+    emptyDatabase(config).then(() => {
+      campsi = new CampsiServer(config.campsi);
+      campsi.mount('docs', new services.Docs(config.services.docs));
+      campsi.app.use((req, res, next) => {
+        req.user = owner;
+        next();
+      });
 
-    campsi = new CampsiServer(config.campsi);
-    campsi.mount('docs', new services.Docs(config.services.docs));
-    campsi.app.use((req, res, next) => {
-      req.user = owner;
-      next();
-    });
-
-    campsi.on('campsi/ready', () => {
-      server = campsi.listen(config.port);
-      done();
-    });
-    campsi.start().catch(err => {
-      debug('Error: %s', err);
+      campsi.on('campsi/ready', () => {
+        server = campsi.listen(config.port);
+        done();
+      });
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 

--- a/test/docs/filters.js
+++ b/test/docs/filters.js
@@ -3,8 +3,6 @@ process.env.NODE_CONFIG_DIR = './config';
 process.env.NODE_ENV = 'test';
 
 // Require the dev-dependencies
-const { MongoClient } = require('mongodb');
-const mongoUriBuilder = require('mongo-uri-builder');
 const debug = require('debug')('campsi:test');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
@@ -12,8 +10,8 @@ const format = require('string-format');
 const CampsiServer = require('campsi');
 const config = require('config');
 const builder = require('../../services/docs/lib/modules/queryBuilder');
-const async = require('async');
 const fakeId = require('fake-object-id');
+const { emptyDatabase } = require('../helpers/emptyDatabase');
 
 chai.should();
 let campsi;
@@ -60,29 +58,22 @@ function testDocument(document, index) {
 
 // Our parent block
 describe('Filter Documents', () => {
-  beforeEach(done => {
-    // Empty the database
-    const mongoUri = mongoUriBuilder(config.campsi.mongo);
-    MongoClient.connect(mongoUri, (err, client) => {
-      if (err) throw err;
-      const db = client.db(config.campsi.mongo.database);
-      db.dropDatabase(() => {
-        client.close();
-        campsi = new CampsiServer(config.campsi);
-        campsi.mount('docs', new services.Docs(config.services.docs));
-        campsi.app.use((req, res, next) => {
-          req.user = owner;
-          next();
-        });
+  beforeEach(async done => {
+    await emptyDatabase(config);
 
-        campsi.on('campsi/ready', () => {
-          server = campsi.listen(config.port);
-          done();
-        });
-        campsi.start().catch(err => {
-          debug('Error: %s', err);
-        });
-      });
+    campsi = new CampsiServer(config.campsi);
+    campsi.mount('docs', new services.Docs(config.services.docs));
+    campsi.app.use((req, res, next) => {
+      req.user = owner;
+      next();
+    });
+
+    campsi.on('campsi/ready', () => {
+      server = campsi.listen(config.port);
+      done();
+    });
+    campsi.start().catch(err => {
+      debug('Error: %s', err);
     });
   });
 

--- a/test/docs/lock-document.js
+++ b/test/docs/lock-document.js
@@ -247,7 +247,7 @@ describe('locks', () => {
         .get(`/docs/pizzas/${docId}/locks`)
         .set('Authorization', 'Bearer ' + adminToken);
 
-      const userId = ObjectId(user._id).toString();
+      const userId = new ObjectId(user._id).toString();
       res.body[0].published.userId.should.eq(userId);
     });
 
@@ -268,8 +268,8 @@ describe('locks', () => {
 
         res.should.have.status(200);
 
-        const userId = ObjectId(user._id).toString();
-        const noOwnerUserId = ObjectId(noOwnerUser._id).toString();
+        const userId = new ObjectId(user._id).toString();
+        const noOwnerUserId = new ObjectId(noOwnerUser._id).toString();
         res.body[0].working_draft.userId.should.eq(noOwnerUserId);
         res.body[1].published.userId.should.eq(userId);
       } catch (err) {

--- a/test/docs/migrate_owner_to_users.js
+++ b/test/docs/migrate_owner_to_users.js
@@ -39,7 +39,7 @@ async function getPizzaById(id) {
 }
 
 // Our parent block
-describe('CRUD', () => {
+describe('Migrate owner to user', () => {
   beforeEach(done => {
     emptyDatabase(config).then(() => {
       campsi = new CampsiServer(config.campsi);
@@ -64,7 +64,7 @@ describe('CRUD', () => {
     createPizza({ name: 'margarita' }, 'published').then(id => {
       getPizzaById(id).then(pizza => {
         pizza.should.have.property('ownedBy');
-        migrate([], campsi.db, ['docs.docs.pizzas'], () => {
+        migrate([], campsi.db, ['docs.docs.pizzas']).then(() => {
           getPizzaById(id).then(pizza => {
             pizza.should.have.property('users');
             done();
@@ -78,7 +78,7 @@ describe('CRUD', () => {
     createPizza({ name: 'margarita' }, 'published').then(id => {
       getPizzaById(id).then(pizza => {
         pizza.should.have.property('ownedBy');
-        migrate(['--remove-ownedBy'], campsi.db, ['docs.docs.pizzas'], () => {
+        migrate(['--remove-ownedBy'], campsi.db, ['docs.docs.pizzas']).then(() => {
           getPizzaById(id).then(pizza => {
             pizza.should.have.property('users');
             pizza.should.not.have.property('ownedBy');

--- a/test/docs/migrate_owner_to_users.js
+++ b/test/docs/migrate_owner_to_users.js
@@ -40,19 +40,19 @@ async function getPizzaById(id) {
 
 // Our parent block
 describe('CRUD', () => {
-  beforeEach(async done => {
-    await emptyDatabase(config);
+  beforeEach(done => {
+    emptyDatabase(config).then(() => {
+      campsi = new CampsiServer(config.campsi);
+      campsi.mount('docs', new services.Docs(config.services.docs));
 
-    campsi = new CampsiServer(config.campsi);
-    campsi.mount('docs', new services.Docs(config.services.docs));
+      campsi.on('campsi/ready', () => {
+        server = campsi.listen(config.port);
+        done();
+      });
 
-    campsi.on('campsi/ready', () => {
-      server = campsi.listen(config.port);
-      done();
-    });
-
-    campsi.start().catch(err => {
-      debug('Error: %s', err);
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 

--- a/test/docs/owner.js
+++ b/test/docs/owner.js
@@ -41,23 +41,23 @@ async function createEntry(data, owner, state) {
 
 // Our parent block
 describe('Owner', () => {
-  beforeEach(async done => {
-    await emptyDatabase(config);
+  beforeEach(done => {
+    emptyDatabase(config).then(() => {
+      campsi = new CampsiServer(config.campsi);
+      campsi.mount('docs', new services.Docs(config.services.docs));
+      campsi.app.use((req, res, next) => {
+        req.user = me;
+        next();
+      });
 
-    campsi = new CampsiServer(config.campsi);
-    campsi.mount('docs', new services.Docs(config.services.docs));
-    campsi.app.use((req, res, next) => {
-      req.user = me;
-      next();
-    });
+      campsi.on('campsi/ready', () => {
+        server = campsi.listen(config.port);
+        done();
+      });
 
-    campsi.on('campsi/ready', () => {
-      server = campsi.listen(config.port);
-      done();
-    });
-
-    campsi.start().catch(err => {
-      debug('Error: %s', err);
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 

--- a/test/docs/pagination.js
+++ b/test/docs/pagination.js
@@ -56,20 +56,20 @@ function createPizzas() {
 
 // Our parent block
 describe('Pagination', () => {
-  before(async done => {
-    await emptyDatabase(config);
+  before(done => {
+    emptyDatabase(config).then(() => {
+      campsi = new CampsiServer(config.campsi);
+      campsi.mount('docs', new services.Docs(config.services.docs));
 
-    campsi = new CampsiServer(config.campsi);
-    campsi.mount('docs', new services.Docs(config.services.docs));
+      campsi.on('campsi/ready', () => {
+        server = campsi.listen(config.port);
 
-    campsi.on('campsi/ready', () => {
-      server = campsi.listen(config.port);
+        createPizzas().then(() => done());
+      });
 
-      createPizzas().then(() => done());
-    });
-
-    campsi.start().catch(err => {
-      debug('Error: %s', err);
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 
@@ -99,13 +99,13 @@ describe('Pagination', () => {
     });
   });
 
-   /*
+  /*
    * Test the /GET docs/pizzas route
    */
-   describe('Test sort', () => {
-    it('it should GET all the pizzas sorted by name in reverse order', async() => {
+  describe('Test sort', () => {
+    it('it should GET all the pizzas sorted by name in reverse order', async () => {
       const res = await chai.request(campsi.app).get('/docs/pizzas/?sort=-data.name');
-    
+
       const pizzas = res?.body;
 
       res.should.have.status(200);
@@ -128,27 +128,27 @@ describe('Pagination', () => {
     });
 
     it('it should GET all the pizzas sorted by name in alphabetical order', async () => {
-        const res = await chai.request(campsi.app).get('/docs/pizzas/?sort=data.name');
-    
-        const pizzas = res?.body;
+      const res = await chai.request(campsi.app).get('/docs/pizzas/?sort=data.name');
 
-        res.should.have.status(200);
-        pizzas.should.be.a('array');
-        pizzas.length.should.be.eq(100);
+      const pizzas = res?.body;
 
-        // check first 5 entries are in the correct order
-        pizzas[0]?.data?.name.should.be.eq('margherita_0');
-        pizzas[1]?.data?.name.should.be.eq('margherita_1');
-        pizzas[2]?.data?.name.should.be.eq('margherita_10');
-        pizzas[3]?.data?.name.should.be.eq('margherita_11');
-        pizzas[4]?.data?.name.should.be.eq('margherita_12');
+      res.should.have.status(200);
+      pizzas.should.be.a('array');
+      pizzas.length.should.be.eq(100);
 
-        // check last 5 entries are in the correct order
-        pizzas[95]?.data?.name.should.be.eq('margherita_95');
-        pizzas[96]?.data?.name.should.be.eq('margherita_96');
-        pizzas[97]?.data?.name.should.be.eq('margherita_97');
-        pizzas[98]?.data?.name.should.be.eq('margherita_98');
-        pizzas[99]?.data?.name.should.be.eq('margherita_99');
+      // check first 5 entries are in the correct order
+      pizzas[0]?.data?.name.should.be.eq('margherita_0');
+      pizzas[1]?.data?.name.should.be.eq('margherita_1');
+      pizzas[2]?.data?.name.should.be.eq('margherita_10');
+      pizzas[3]?.data?.name.should.be.eq('margherita_11');
+      pizzas[4]?.data?.name.should.be.eq('margherita_12');
+
+      // check last 5 entries are in the correct order
+      pizzas[95]?.data?.name.should.be.eq('margherita_95');
+      pizzas[96]?.data?.name.should.be.eq('margherita_96');
+      pizzas[97]?.data?.name.should.be.eq('margherita_97');
+      pizzas[98]?.data?.name.should.be.eq('margherita_98');
+      pizzas[99]?.data?.name.should.be.eq('margherita_99');
     });
   });
 

--- a/test/docs/state.js
+++ b/test/docs/state.js
@@ -32,19 +32,19 @@ async function createPizza(data, state) {
 }
 
 describe('State', () => {
-  beforeEach(async done => {
-    await emptyDatabase(config);
+  beforeEach(done => {
+    emptyDatabase(config).then(() => {
+      campsi = new CampsiServer(config.campsi);
+      campsi.mount('docs', new services.Docs(config.services.docs));
 
-    campsi = new CampsiServer(config.campsi);
-    campsi.mount('docs', new services.Docs(config.services.docs));
+      campsi.on('campsi/ready', () => {
+        server = campsi.listen(config.port);
+        done();
+      });
 
-    campsi.on('campsi/ready', () => {
-      server = campsi.listen(config.port);
-      done();
-    });
-
-    campsi.start().catch(err => {
-      debug('Error: %s', err);
+      campsi.start().catch(err => {
+        debug('Error: %s', err);
+      });
     });
   });
 

--- a/test/docs/state.js
+++ b/test/docs/state.js
@@ -3,8 +3,6 @@ process.env.NODE_CONFIG_DIR = './test/docs/config';
 process.env.NODE_ENV = 'test';
 
 // Require the dev-dependencies
-const { MongoClient } = require('mongodb');
-const mongoUriBuilder = require('mongo-uri-builder');
 const debug = require('debug')('campsi:test');
 const async = require('async');
 const chai = require('chai');
@@ -13,6 +11,7 @@ const format = require('string-format');
 const CampsiServer = require('campsi');
 const config = require('config');
 const builder = require('../../services/docs/lib/modules/queryBuilder');
+const { emptyDatabase } = require('../helpers/emptyDatabase');
 
 const should = chai.should();
 let campsi;
@@ -25,49 +24,27 @@ const services = {
 };
 
 // Helpers
-function createPizza(data, state) {
-  return new Promise(function(resolve, reject) {
-    const resource = campsi.services.get('docs').options.resources.pizzas;
-    builder
-      .create({
-        user: null,
-        data,
-        resource,
-        state
-      })
-      .then(doc => {
-        resource.collection.insertOne(doc, (err, result) => {
-          if (err) return reject(err);
-          resolve(result.insertedId);
-        });
-      })
-      .catch(error => {
-        reject(error);
-      });
-  });
+async function createPizza(data, state) {
+  const resource = campsi.services.get('docs').options.resources.pizzas;
+  const doc = await builder.create({ user: null, data, resource, state });
+  const result = await resource.collection.insertOne(doc);
+  return result.insertedId;
 }
 
 describe('State', () => {
-  beforeEach(done => {
-    // Empty the database
-    const mongoUri = mongoUriBuilder(config.campsi.mongo);
-    MongoClient.connect(mongoUri, (err, client) => {
-      if (err) throw err;
-      const db = client.db(config.campsi.mongo.database);
-      db.dropDatabase(() => {
-        client.close();
-        campsi = new CampsiServer(config.campsi);
-        campsi.mount('docs', new services.Docs(config.services.docs));
+  beforeEach(async done => {
+    await emptyDatabase(config);
 
-        campsi.on('campsi/ready', () => {
-          server = campsi.listen(config.port);
-          done();
-        });
+    campsi = new CampsiServer(config.campsi);
+    campsi.mount('docs', new services.Docs(config.services.docs));
 
-        campsi.start().catch(err => {
-          debug('Error: %s', err);
-        });
-      });
+    campsi.on('campsi/ready', () => {
+      server = campsi.listen(config.port);
+      done();
+    });
+
+    campsi.start().catch(err => {
+      debug('Error: %s', err);
     });
   });
 
@@ -208,7 +185,7 @@ describe('State', () => {
         .then(id => {
           async.series(
             [
-              function(cb) {
+              function (cb) {
                 chai
                   .request(campsi.app)
                   .put('/docs/pizzas/{0}/working_draft'.format(id))
@@ -230,7 +207,7 @@ describe('State', () => {
                     cb();
                   });
               },
-              function(cb) {
+              function (cb) {
                 chai
                   .request(campsi.app)
                   .get('/docs/pizzas/{0}/working_draft'.format(id))

--- a/test/docs/utils/initialization.js
+++ b/test/docs/utils/initialization.js
@@ -1,10 +1,8 @@
-const { MongoClient } = require('mongodb');
-const mongoUriBuilder = require('mongo-uri-builder');
 const CampsiServer = require('campsi');
-const debug = require('debug')('campsi-test');
 const format = require('string-format');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
+const { emptyDatabase } = require('../../helpers/emptyDatabase');
 format.extend(String.prototype);
 chai.use(chaiHttp);
 chai.should();
@@ -20,19 +18,9 @@ module.exports = function initialize(config, services) {
   campsi.start();
   return {
     campsi,
-    beforeEachCallback: done => {
-      // Empty the database
-      const mongoUri = mongoUriBuilder(config.campsi.mongo);
-      MongoClient.connect(mongoUri, (err, client) => {
-        if (err) {
-          debug('Error during the mongo connection', err);
-        }
-        const db = client.db(config.campsi.mongo.database);
-        db.dropDatabase(() => {
-          client.close();
-          done();
-        });
-      });
+    beforeEachCallback: async done => {
+      await emptyDatabase(config);
+      done();
     },
     afterCallback: done => {
       campsi.server.close();

--- a/test/helpers/emptyDatabase.js
+++ b/test/helpers/emptyDatabase.js
@@ -1,0 +1,10 @@
+const mongoUriBuilder = require('mongo-uri-builder');
+const { MongoClient } = require('mongodb');
+
+module.exports.emptyDatabase = async config => {
+  const mongoUri = mongoUriBuilder(config.campsi.mongo);
+  const client = await MongoClient.connect(mongoUri);
+  const db = client.db(config.campsi.mongo.database);
+  await db.dropDatabase();
+  await client.close();
+};

--- a/test/helpers/setupBeforeEach.js
+++ b/test/helpers/setupBeforeEach.js
@@ -2,16 +2,19 @@ const CampsiServer = require('campsi');
 const { emptyDatabase } = require('./emptyDatabase');
 const debug = require('debug')('campsi:test');
 
-module.exports = async (config, services, context) => {
-  await emptyDatabase(config);
-  context.campsi = new CampsiServer(config.campsi);
-  Object.entries(services).map(([name, service]) => {
-    // eslint-disable-next-line new-cap
-    return context.campsi.mount(name.toLowerCase(), new service(config.services[name.toLowerCase()]));
-  });
+module.exports = (config, services, context) => done => {
+  emptyDatabase(config).then(() => {
+    context.campsi = new CampsiServer(config.campsi);
+    Object.entries(services).map(([name, service]) => {
+      // eslint-disable-next-line new-cap
+      return context.campsi.mount(name.toLowerCase(), new service(config.services[name.toLowerCase()]));
+    });
 
-  context.campsi.on('campsi/ready', () => {
-    context.server = context.campsi.listen(config.port);
+    context.campsi.on('campsi/ready', () => {
+      context.server = context.campsi.listen(config.port);
+      done();
+    });
+
+    context.campsi.start();
   });
-  return await context.campsi.start();
 };

--- a/test/helpers/setupBeforeEach.js
+++ b/test/helpers/setupBeforeEach.js
@@ -1,28 +1,20 @@
 const CampsiServer = require('campsi');
-const { MongoClient } = require('mongodb');
-const mongoUriBuilder = require('mongo-uri-builder');
+const { emptyDatabase } = require('./emptyDatabase');
 const debug = require('debug')('campsi:test');
 
-module.exports = (config, services, context) => done => {
-  const mongoUri = mongoUriBuilder(config.campsi.mongo);
-  MongoClient.connect(mongoUri, (err, client) => {
-    if (err) throw err;
-    const db = client.db(config.campsi.mongo.database);
-    db.dropDatabase(() => {
-      client.close();
-      context.campsi = new CampsiServer(config.campsi);
-      Object.entries(services).map(([name, service]) => {
-        // eslint-disable-next-line new-cap
-        return context.campsi.mount(name.toLowerCase(), new service(config.services[name.toLowerCase()]));
-      });
+module.exports = (config, services, context) => async done => {
+  await emptyDatabase(config);
+  context.campsi = new CampsiServer(config.campsi);
+  Object.entries(services).map(([name, service]) => {
+    // eslint-disable-next-line new-cap
+    return context.campsi.mount(name.toLowerCase(), new service(config.services[name.toLowerCase()]));
+  });
 
-      context.campsi.on('campsi/ready', () => {
-        context.server = context.campsi.listen(config.port);
-        done();
-      });
-      context.campsi.start().catch(err => {
-        debug('Error: %s', err);
-      });
-    });
+  context.campsi.on('campsi/ready', () => {
+    context.server = context.campsi.listen(config.port);
+    done();
+  });
+  context.campsi.start().catch(err => {
+    debug('Error: %s', err);
   });
 };

--- a/test/helpers/setupBeforeEach.js
+++ b/test/helpers/setupBeforeEach.js
@@ -2,7 +2,7 @@ const CampsiServer = require('campsi');
 const { emptyDatabase } = require('./emptyDatabase');
 const debug = require('debug')('campsi:test');
 
-module.exports = (config, services, context) => async done => {
+module.exports = async (config, services, context) => {
   await emptyDatabase(config);
   context.campsi = new CampsiServer(config.campsi);
   Object.entries(services).map(([name, service]) => {
@@ -12,9 +12,6 @@ module.exports = (config, services, context) => async done => {
 
   context.campsi.on('campsi/ready', () => {
     context.server = context.campsi.listen(config.port);
-    done();
   });
-  context.campsi.start().catch(err => {
-    debug('Error: %s', err);
-  });
+  return await context.campsi.start();
 };

--- a/test/webhooks/setupBeforeEach.js
+++ b/test/webhooks/setupBeforeEach.js
@@ -1,25 +1,18 @@
 const CampsiServer = require('campsi');
-const { MongoClient } = require('mongodb');
-const mongoUriBuilder = require('mongo-uri-builder');
+const { emptyDatabase } = require('../helpers/emptyDatabase');
 const debug = require('debug')('campsi:test');
 
-module.exports = (config, services, context) => done => {
-  const mongoUri = mongoUriBuilder(config.campsi.mongo);
-  MongoClient.connect(mongoUri, (err, client) => {
-    if (err) throw err;
-    const db = client.db(config.campsi.mongo.database);
-    db.dropDatabase(() => {
-      client.close();
-      context.campsi = new CampsiServer(config.campsi);
-      context.campsi.mount('trace', new services.Trace(config.services.trace));
-      context.campsi.mount('webhooks', new services.Webhooks(config.services.webHooks));
-      context.campsi.on('campsi/ready', () => {
-        context.server = context.campsi.listen(config.port);
-        done();
-      });
-      context.campsi.start().catch(err => {
-        debug('Error: %s', err);
-      });
-    });
+module.exports = (config, services, context) => async done => {
+  await emptyDatabase(config);
+
+  context.campsi = new CampsiServer(config.campsi);
+  context.campsi.mount('trace', new services.Trace(config.services.trace));
+  context.campsi.mount('webhooks', new services.Webhooks(config.services.webHooks));
+  context.campsi.on('campsi/ready', () => {
+    context.server = context.campsi.listen(config.port);
+    done();
+  });
+  context.campsi.start().catch(err => {
+    debug('Error: %s', err);
   });
 };


### PR DESCRIPTION
title self -explanatory

- count() deprecated on cursor and collection
- callbacks are deprecated and will be removed in the next major release
- Class constructor ObjectId cannot be invoked without 'new'

MongoDB driver changelog [here](https://www.mongodb.com/docs/drivers/node/current/whats-new/)
