### PR TITLE
Dev 2977 change swagger comments in doc service

### DIFF
--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -29,7 +29,7 @@ module.exports = class DocsService extends CampsiService {
       next();
     });
     this.router.param(
-      // #swagger.tags = ['{DOCSERVICE}']
+      // #swagger.tags = ['DOCSERVICE']
       // #swagger.ignore = always
       'resource',
       param.attachResource(service.options)

--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -30,14 +30,14 @@ module.exports = class DocsService extends CampsiService {
     });
     this.router.param(
       // #swagger.tags = ['{DOCSERVICE}']
-      // #swagger.ignore = true
+      // #swagger.ignore = always
       'resource',
       param.attachResource(service.options)
     );
     this.router.get(
       '/',
       // #swagger.tags = ['DOCSERVICE']
-      // #swagger.ignore = true
+      // #swagger.ignore = always
       handlers.getResources
     );
     this.router.get(


### PR DESCRIPTION
This PR changes the comments tagged as ignore = true to ignore = always if the route is never to be excluded from the swagger autogen process. This was only needed for the route '/' which clashes if there are several endpoints overriding the docs service as is the case in caas-api for example