### PR TITLE
feat: refactor paginate cursor for better efficiency (DEV-3089)

### DIFF
--- a/lib/modules/paginateCursor.js
+++ b/lib/modules/paginateCursor.js
@@ -64,7 +64,13 @@ const preparePagination = (count, skip, limit, page, perPage) => {
   };
 };
 
-module.exports.paginateWithCount = (count, options) => {
+/**
+ *
+ * @param {int} count
+ * @param {Object}  options
+ * @returns {{perPage: number, lastPage: (number|number), count: number, limit: number, skip: number, page: number}}
+ */
+const paginateWithCount = (count, options) => {
   const params = { ...PAGINATE_DEFAULTS, ...options };
 
   let page = parseInt(params.page);
@@ -75,6 +81,27 @@ module.exports.paginateWithCount = (count, options) => {
   page = Math.min(Math.max(page, 1), lastPage);
 
   return { count, page, perPage, skip, limit, lastPage };
+};
+
+/**
+ *
+ * @param {Object} collectionConnection  mongodb connection to the collection
+ * @param {Object|Array}  query either a query filter object, or an aggregation pipeline array
+ * @param {Object}  options pagination options
+ * @returns {Promise<{perPage: number, lastPage: (number|number), count: number, limit: number, skip: number, page: number}>}
+ */
+module.exports.paginateQuery = async (collectionConnection, query, options) => {
+  const isAggregation = Array.isArray(query);
+  let count;
+
+  if (!isAggregation) {
+    count = await collectionConnection.countDocuments(query);
+  } else {
+    const aggregateCount = await collectionConnection.aggregate([...query, { _id: null, count: { $sum: 1 } }]).toArray();
+    count = aggregateCount[0].count;
+  }
+
+  return paginateWithCount(count, options);
 };
 
 module.exports.defaults = PAGINATE_DEFAULTS;

--- a/lib/modules/paginateCursor.js
+++ b/lib/modules/paginateCursor.js
@@ -2,7 +2,7 @@ const AggregationCursor = require('mongodb').AggregationCursor;
 // eslint-disable-next-line no-unused-vars
 const FindCursor = require('mongodb').FindCursor;
 
-const defaults = {
+const PAGINATE_DEFAULTS = {
   page: 1,
   perPage: 100
 };
@@ -17,7 +17,7 @@ const defaults = {
  */
 module.exports = function paginateCursor(cursor, options) {
   return new Promise((resolve, reject) => {
-    const params = Object.assign({}, defaults, options);
+    const params = Object.assign({}, PAGINATE_DEFAULTS, options);
     // page, perPage
     const page = parseInt(params.page);
     const perPage = parseInt(params.perPage);
@@ -64,4 +64,17 @@ const preparePagination = (count, skip, limit, page, perPage) => {
   };
 };
 
-module.exports.defaults = defaults;
+module.exports.paginateWithCount = (count, options) => {
+  const params = { ...PAGINATE_DEFAULTS, ...options };
+
+  let page = parseInt(params.page);
+  const perPage = parseInt(params.perPage);
+  const skip = (page - 1) * parseInt(params.perPage);
+  const limit = parseInt(params.perPage);
+  const lastPage = count === 0 ? 1 : Math.ceil(count / perPage);
+  page = Math.min(Math.max(page, 1), lastPage);
+
+  return { count, page, perPage, skip, limit, lastPage };
+};
+
+module.exports.defaults = PAGINATE_DEFAULTS;

--- a/lib/modules/paginateCursor.js
+++ b/lib/modules/paginateCursor.js
@@ -65,12 +65,24 @@ const preparePagination = (count, skip, limit, page, perPage) => {
 };
 
 /**
- *
- * @param {int} count
- * @param {Object}  options
- * @returns {{perPage: number, lastPage: (number|number), count: number, limit: number, skip: number, page: number}}
+ * prepare an object for pagination results
+ * @param {Object} collectionConnection  mongodb connection to the collection
+ * @param {Object|Array}  query either a query filter object, or an aggregation pipeline array
+ * @param {Object}  options pagination options
+ * @returns {Promise<{skip: number, limit: number, count: number, page: number, perPage: number, nav: { first: number, last: number, previous: ?number, next: ?number}}>}
  */
-const paginateWithCount = (count, options) => {
+module.exports.paginateQuery = async (collectionConnection, query, options) => {
+  const isAggregation = Array.isArray(query);
+  let count;
+  if (!isAggregation) {
+    count = await collectionConnection.countDocuments(query);
+  } else {
+    const aggregateCount = await collectionConnection
+      .aggregate([...query, { $group: { _id: null, count: { $sum: 1 } } }])
+      .toArray();
+    count = aggregateCount[0]?.count || 0;
+  }
+
   const params = { ...PAGINATE_DEFAULTS, ...options };
 
   let page = parseInt(params.page);
@@ -80,28 +92,19 @@ const paginateWithCount = (count, options) => {
   const lastPage = count === 0 ? 1 : Math.ceil(count / perPage);
   page = Math.min(Math.max(page, 1), lastPage);
 
-  return { count, page, perPage, skip, limit, lastPage };
-};
-
-/**
- *
- * @param {Object} collectionConnection  mongodb connection to the collection
- * @param {Object|Array}  query either a query filter object, or an aggregation pipeline array
- * @param {Object}  options pagination options
- * @returns {Promise<{perPage: number, lastPage: (number|number), count: number, limit: number, skip: number, page: number}>}
- */
-module.exports.paginateQuery = async (collectionConnection, query, options) => {
-  const isAggregation = Array.isArray(query);
-  let count;
-
-  if (!isAggregation) {
-    count = await collectionConnection.countDocuments(query);
-  } else {
-    const aggregateCount = await collectionConnection.aggregate([...query, { _id: null, count: { $sum: 1 } }]).toArray();
-    count = aggregateCount[0].count;
-  }
-
-  return paginateWithCount(count, options);
+  return {
+    skip,
+    limit,
+    count,
+    page,
+    perPage,
+    nav: {
+      first: 1,
+      last: lastPage,
+      previous: page > 1 ? page - 1 : undefined,
+      next: page < lastPage ? page + 1 : undefined
+    }
+  };
 };
 
 module.exports.defaults = PAGINATE_DEFAULTS;

--- a/services/assets/lib/services/asset.js
+++ b/services/assets/lib/services/asset.js
@@ -8,14 +8,8 @@ const { ObjectId } = require('mongodb');
 
 module.exports.getAssets = async function (service, pagination, sort) {
   try {
-    const { count, page, perPage, skip, limit, lastPage } = await paginateQuery(service.collection, {}, pagination);
-    const result = { count, page, perPage, nav: { first: 1, last: lastPage } };
-    if (page > 1) {
-      result.nav.previous = page - 1;
-    }
-    if (page < lastPage) {
-      result.nav.next = page + 1;
-    }
+    const { skip, limit, ...result } = await paginateQuery(service.collection, {}, pagination);
+
     const findOptions = { limit, skip };
     if (sort) {
       findOptions.sort = sortCursor(undefined, sort, undefined, true);

--- a/services/assets/lib/services/asset.js
+++ b/services/assets/lib/services/asset.js
@@ -2,29 +2,21 @@
 /* eslint-disable node/no-unpublished-require */
 const async = require('async');
 const debug = require('debug')('campsi:service:assets');
-const { paginateWithCount } = require('../../../../lib/modules/paginateCursor');
+const { paginateQuery } = require('../../../../lib/modules/paginateCursor');
 const sortCursor = require('../../../../lib/modules/sortCursor');
 const { ObjectId } = require('mongodb');
 
 module.exports.getAssets = async function (service, pagination, sort) {
   try {
-    const docsCount = await service.collection.countDocuments({});
-    const result = {};
-
-    const info = paginateWithCount(docsCount, pagination);
-    result.count = info.count;
-    result.page = info.page;
-    result.perPage = info.perPage;
-    result.nav = {};
-    result.nav.first = 1;
-    result.nav.last = info.lastPage;
-    if (info.page > 1) {
-      result.nav.previous = info.page - 1;
+    const { count, page, perPage, skip, limit, lastPage } = await paginateQuery(service.collection, {}, pagination);
+    const result = { count, page, perPage, nav: { first: 1, last: lastPage } };
+    if (page > 1) {
+      result.nav.previous = page - 1;
     }
-    if (info.page < info.lastPage) {
-      result.nav.next = info.page + 1;
+    if (page < lastPage) {
+      result.nav.next = page + 1;
     }
-    const findOptions = { limit: info.limit, skip: info.skip };
+    const findOptions = { limit, skip };
     if (sort) {
       findOptions.sort = sortCursor(undefined, sort, undefined, true);
     }

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -81,7 +81,7 @@ module.exports.getDocuments = function (req, res) {
 
       return helpers.json(res, data.docs, headers);
     })
-    .catch(() => {
+    .catch(err => {
       helpers.notFound(res);
     });
 };

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -1,6 +1,5 @@
 const builder = require('../modules/queryBuilder');
 const embedDocs = require('../modules/embedDocs');
-const paginateCursor = require('../../../../lib/modules/paginateCursor');
 const sortCursor = require('../../../../lib/modules/sortCursor');
 const createObjectId = require('../../../../lib/modules/createObjectId');
 const permissions = require('../modules/permissions');
@@ -248,18 +247,8 @@ module.exports.getDocuments = async function (resource, filter, user, query, sta
     $project: dbFields
   });
 
-  const { count, page, perPage, skip, limit, lastPage } = await paginateQuery(
-    resource.collection,
-    aggregate ? pipeline : dbQuery,
-    pagination
-  );
-  const result = { count, page, perPage, nav: { first: 1, last: lastPage }, label: resource.label };
-  if (page > 1) {
-    result.nav.previous = page - 1;
-  }
-  if (page < lastPage) {
-    result.nav.next = page + 1;
-  }
+  const { skip, limit, ...result } = await paginateQuery(resource.collection, aggregate ? pipeline : dbQuery, pagination);
+  result.label = resource.label;
 
   if (sort) {
     sort = sortCursor(

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -9,6 +9,7 @@ const { ObjectId } = require('mongodb');
 const createError = require('http-errors');
 const { getDocumentLockServiceOptions } = require('../modules/serviceOptions');
 const { getUsersCollectionName } = require('../../../auth/lib/modules/collectionNames');
+const { paginateQuery } = require('../../../../lib/modules/paginateCursor');
 
 // Helper functions
 const getDocUsersList = doc => Object.keys(doc ? doc.users : []).map(k => doc.users[k]);
@@ -176,28 +177,15 @@ module.exports.lockDocument = async function (resource, state, filter, tokenTime
   }
 };
 
-module.exports.getDocuments = function (resource, filter, user, query, state, sort, pagination, resources) {
-  const queryBuilderOptions = {
-    resource,
-    user,
-    query,
-    state
-  };
+module.exports.getDocuments = async function (resource, filter, user, query, state, sort, pagination, resources) {
+  const queryBuilderOptions = { resource, user, query, state };
   const filterState = {};
   filterState[`states.${state}`] = { $exists: true };
   const dbQuery = Object.assign(filterState, filter, builder.find(queryBuilderOptions));
 
-  const dbFields = {
-    _id: 1,
-    states: 1,
-    users: 1,
-    groups: 1
-  };
+  const dbFields = { _id: 1, states: 1, users: 1, groups: 1 };
 
-  let aggregate = false;
-  if (resource.isInheritable || query?.with?.includes('creator')) {
-    aggregate = true;
-  }
+  const aggregate = !!resource.isInheritable || query?.with?.includes('creator');
 
   const pipeline = [{ $match: dbQuery }];
 
@@ -225,11 +213,7 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
                 }
               }
             }
-          }
-        }
-      },
-      {
-        $addFields: {
+          },
           [`states.${state}.data`]: {
             $mergeObjects: [`$parent.states.${state}.data`, `$$ROOT.states.${state}.data`]
           }
@@ -239,11 +223,7 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
   }
 
   if (query?.with?.includes('creator')) {
-    dbFields.creator = {
-      _id: 1,
-      displayName: 1,
-      email: 1
-    };
+    dbFields.creator = { _id: 1, displayName: 1, email: 1 };
 
     pipeline.push(
       {
@@ -268,75 +248,65 @@ module.exports.getDocuments = function (resource, filter, user, query, state, so
     $project: dbFields
   });
 
-  if (sort) {
-    pipeline.push({
-      $sort: sortCursor(
-        null,
-        sort,
-        sort.startsWith('data') || sort.startsWith('-data') ? 'states.{}.data.'.format(state) : '',
-        true
-      )
-    });
+  const { count, page, perPage, skip, limit, lastPage } = await paginateQuery(
+    resource.collection,
+    aggregate ? pipeline : dbQuery,
+    pagination
+  );
+  const result = { count, page, perPage, nav: { first: 1, last: lastPage }, label: resource.label };
+  if (page > 1) {
+    result.nav.previous = page - 1;
   }
-  const cursor = !aggregate
-    ? resource.collection.find(dbQuery, { projection: dbFields })
-    : resource.collection.aggregate(pipeline);
+  if (page < lastPage) {
+    result.nav.next = page + 1;
+  }
+
+  if (sort) {
+    sort = sortCursor(
+      undefined,
+      sort,
+      sort.startsWith('data') || sort.startsWith('-data') ? 'states.{}.data.'.format(state) : '',
+      true
+    );
+  }
+
   const requestedStates = getRequestedStatesFromQuery(resource, query);
-  const result = {};
-  return new Promise((resolve, reject) => {
-    paginateCursor(cursor, pagination)
-      .then(info => {
-        result.count = info.count;
-        result.label = resource.label;
-        result.page = info.page;
-        result.perPage = info.perPage;
-        result.nav = {};
-        result.nav.first = 1;
-        result.nav.last = info.lastPage;
-        if (info.page > 1) {
-          result.nav.previous = info.page - 1;
-        }
-        if (info.page < info.lastPage) {
-          result.nav.next = info.page + 1;
-        }
-        if (sort && !aggregate) {
-          sortCursor(cursor, sort, sort.startsWith('data') || sort.startsWith('-data') ? 'states.{}.data.'.format(state) : '');
-        }
-        return cursor.toArray();
-      })
-      .then(docs => {
-        result.docs = docs.map(doc => {
-          const currentState = doc.states[state] || {};
-          const allowedStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'GET', doc);
-          const states = permissions.filterDocumentStates(doc, allowedStates, requestedStates);
-          const returnData = {
-            id: doc._id,
-            state,
-            states,
-            createdAt: currentState.createdAt,
-            createdBy: currentState.createdBy,
-            data: currentState.data || {}
-          };
-          if (resource.isInheritable && query?.with?.includes('parentId')) {
-            returnData.parentId = doc.parentId;
-          }
-          if (query?.with?.includes('creator')) {
-            returnData.creator = doc.creator;
-          }
 
-          addVirtualProperties(resource, returnData.data);
+  let docsQuery = (
+    aggregate ? resource.collection.aggregate(pipeline) : resource.collection.find(dbQuery, { projection: dbFields })
+  )
+    .skip(skip)
+    .limit(limit);
+  if (sort) {
+    docsQuery = docsQuery.sort(sort);
+  }
 
-          return returnData;
-        });
-        return embedDocs.many(resource, query.embed, user, result.docs, resources);
-      })
-      .then(() => {
-        return resolve(result);
-      })
-      .catch(err => {
-        return reject(err);
-      });
+  const docs = await docsQuery.toArray();
+  result.docs = docs.map(doc => {
+    const currentState = doc.states[state] || {};
+    const allowedStates = permissions.getAllowedStatesFromDocForUser(user, resource, 'GET', doc);
+    const states = permissions.filterDocumentStates(doc, allowedStates, requestedStates);
+    const returnData = {
+      id: doc._id,
+      state,
+      states,
+      createdAt: currentState.createdAt,
+      createdBy: currentState.createdBy,
+      data: currentState.data || {}
+    };
+    if (resource.isInheritable && query?.with?.includes('parentId')) {
+      returnData.parentId = doc.parentId;
+    }
+    if (query?.with?.includes('creator')) {
+      returnData.creator = doc.creator;
+    }
+
+    addVirtualProperties(resource, returnData.data);
+
+    return returnData;
   });
+  await embedDocs.many(resource, query.embed, user, result.docs, resources);
+  return result;
 };
 
 module.exports.createDocument = async function (resource, data, state, user, parentId, groups) {

--- a/services/versioned-docs/lib/services/document.js
+++ b/services/versioned-docs/lib/services/document.js
@@ -2,7 +2,7 @@
 const { diff } = require('just-diff');
 const { ObjectId } = require('mongodb');
 const builder = require('../modules/queryBuilder');
-const paginateCursor = require('../../../../lib/modules/paginateCursor');
+const { paginateQuery } = require('../../../../lib/modules/paginateCursor');
 const sortCursor = require('../../../../lib/modules/sortCursor');
 const createObjectId = require('../../../../lib/modules/createObjectId');
 const createError = require('http-errors');
@@ -181,7 +181,7 @@ module.exports.getDocuments = async (resource, filter, user, query, sort, pagina
 
   const dbQuery = { ...filter, ...builder.find(queryBuilderOptions) };
 
-  const aggregate = query?.with?.includes('creator') || false;
+  const aggregate = query?.with?.includes('creator');
 
   const pipeline = [{ $match: dbQuery }];
 
@@ -189,28 +189,21 @@ module.exports.getDocuments = async (resource, filter, user, query, sort, pagina
     pipeline.push(...getDocumentCreatorPipeline());
   }
 
-  const cursor = !aggregate ? resource.currentCollection.find(dbQuery) : resource.currentCollection.aggregate(pipeline);
-
-  let result = {};
-
-  const { count, page, lastPage, perPage } = await paginateCursor(cursor, pagination);
-  result = {
-    ...result,
-    count,
-    page,
-    perPage,
-    label: resource.label,
-    nav: {
-      first: 1,
-      last: lastPage,
-      previous: page > 1 ? page - 1 : undefined,
-      next: page < lastPage ? page + 1 : undefined
-    }
-  };
   if (sort) {
-    sortCursor(cursor, sort, '');
+    sort = sortCursor(undefined, sort, undefined, true);
   }
-  result.docs = await cursor.toArray();
+
+  const { skip, limit, ...result } = await paginateQuery(resource.currentCollection, aggregate ? pipeline : dbQuery, pagination);
+  result.label = resource.label;
+
+  let docsQuery = (aggregate ? resource.currentCollection.aggregate(pipeline) : resource.currentCollection.find(dbQuery))
+    .skip(skip)
+    .limit(limit);
+  if (sort) {
+    docsQuery = docsQuery.sort(sort);
+  }
+  result.docs = await docsQuery.toArray();
+
   return result;
 };
 


### PR DESCRIPTION
pagination was previously using `paginateCursor`, which basically execute the query to get the number of documents (now that `cursor.count()` is deprecated), then rewind the cursor, apply skip/limit/sort and execute the query once again.
That's not very efficient and can be slow, especially when the number of documents is huge. 

I've refactored it to use `countDocuments` (when possible) instead, and removed old promise syntax too.

Unit tests results all green
