### PR TITLE
fix: disable multiple identity providers for the same user (DEV-3353)

### DIFF
--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -237,7 +237,6 @@ function callback(req, res) {
         debug('session destroyed');
       });
     }
-    return deleteExpiredTokens(req.user.tokens, req.user._id, req.db);
   });
 }
 

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -161,7 +161,7 @@ module.exports = class AuthService extends CampsiService {
         '/local/signup',
         local.signup
       );
-      router.postAsync(
+      router.post(
         /*
         #swagger.tags = ['Auth service'],
         #swagger.description = 'AUTH_LOCAL_SIGNIN_DESCRIPTION'
@@ -221,7 +221,7 @@ module.exports = class AuthService extends CampsiService {
       '/:provider',
       handlers.initAuth
     );
-    this.router.getAsync(
+    this.router.get(
       // #swagger.ignore = true,
       '/:provider/callback',
       handlers.callback

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -161,7 +161,7 @@ module.exports = class AuthService extends CampsiService {
         '/local/signup',
         local.signup
       );
-      router.post(
+      router.postAsync(
         /*
         #swagger.tags = ['Auth service'],
         #swagger.description = 'AUTH_LOCAL_SIGNIN_DESCRIPTION'
@@ -221,7 +221,7 @@ module.exports = class AuthService extends CampsiService {
       '/:provider',
       handlers.initAuth
     );
-    this.router.get(
+    this.router.getAsync(
       // #swagger.ignore = true,
       '/:provider/callback',
       handlers.callback

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -31,10 +31,10 @@ module.exports.middleware = function (localProvider) {
   };
 };
 
-module.exports.signin = function (req, res) {
+module.exports.signin = function (req, res, next) {
   // could be a one-liner, but I find this more explicit
   // the real signin method is the callback below
-  return handlers.callback(req, res);
+  return handlers.callback(req, res, next);
 };
 
 /**

--- a/services/auth/lib/passportMiddleware.js
+++ b/services/auth/lib/passportMiddleware.js
@@ -54,9 +54,11 @@ module.exports = function passportMiddleware(req) {
         .map(([key, value]) => key);
       let providersToRemove = [];
 
-      if (existingProvidersIdentities.length === 1 && existingProvidersIdentities[0] !== provider.name) {
-        // user exists, has one identity, but not the one we are trying to login with: we return an error with the provider the user should login with
-        return passportCallback(createError(409, `user already exists with identity provider ${existingProvidersIdentities[0]}`));
+      if (existingProvidersIdentities.length >= 1 && !existingProvidersIdentities.includes(provider.name)) {
+        // user exists, has one on more identities, but not the one we are trying to login with: we return an error with providers the user should login with
+        return passportCallback(
+          createError(409, `user already exists with identity providers ${existingProvidersIdentities.split(', ')}`)
+        );
       } else if (existingProvidersIdentities.length > 1) {
         // user exists and has multiple identities: we update it by removing the other ones, to keep only the one the user is trying to login with
         update.$unset = existingProvidersIdentities.reduce((acc, key) => {

--- a/services/auth/lib/passportMiddleware.js
+++ b/services/auth/lib/passportMiddleware.js
@@ -52,12 +52,12 @@ module.exports = function passportMiddleware(req) {
         .filter(([key, value]) => !!availableProviders[key] && !!value.id)
         .map(([key, value]) => key);
       if (existingProvidersIdentities.length === 1 && existingProvidersIdentities[0] !== provider.name) {
-        // user exists, has one identity, but not the one we are trying to login with: we return an error with the provider it should login with
+        // user exists, has one identity, but not the one we are trying to login with: we return an error with the provider the user should login with
         return passportCallback(
           'user exists, has one identity, but not the one we are trying to login with: we return an error with the provider it should login with'
         );
       } else if (existingProvidersIdentities.length > 1) {
-        // user exists and has multiple identities: we update it by removing the other ones, to keep only the one we are trying to login
+        // user exists and has multiple identities: we update it by removing the other ones, to keep only the one the user is trying to login with
         update.$unset = existingProvidersIdentities.reduce((acc, key) => {
           if (key !== provider.name) {
             acc[`identities.${key}`] = '';

--- a/services/auth/lib/tokens.js
+++ b/services/auth/lib/tokens.js
@@ -34,7 +34,7 @@ async function deleteExpiredTokens(tokens, userId, db, providersToRemove = []) {
 
       if (Object.entries(tokens.length !== Object.entries(validTokens).length)) {
         await db
-          .collection('__users__')
+          .collection(getUsersCollectionName())
           .updateOne({ _id: userId }, { $set: { tokens: validTokens } }, { returnDocument: 'after' });
       }
     }

--- a/services/auth/lib/tokens.js
+++ b/services/auth/lib/tokens.js
@@ -11,32 +11,30 @@ async function deleteExpiredTokens(tokens, userId, db, providersToRemove = []) {
     }
 
     // iterate over users tokens
-    if (Object.entries(tokens)) {
-      for (const [key, token] of Object.entries(tokens)) {
-        if (token.expiration > new Date() && !providersToRemove.includes(token.provider)) {
-          validTokens[`${key}`] = token;
-        } else {
-          expiredTokensLog.push({
-            userId,
-            token: key,
-            ...token
-          });
-        }
+    for (const [key, token] of Object.entries(tokens)) {
+      if (token.expiration > new Date() && !providersToRemove.includes(token.provider)) {
+        validTokens[`${key}`] = token;
+      } else {
+        expiredTokensLog.push({
+          userId,
+          token: key,
+          ...token
+        });
       }
+    }
 
-      if (expiredTokensLog.length) {
-        try {
-          await db.collection(`${getUsersCollectionName()}.tokens_log`).insertMany(expiredTokensLog);
-        } catch (ex) {
-          debug(ex);
-        }
+    if (expiredTokensLog.length) {
+      try {
+        await db.collection(`${getUsersCollectionName()}.tokens_log`).insertMany(expiredTokensLog);
+      } catch (ex) {
+        debug(ex);
       }
+    }
 
-      if (Object.entries(tokens.length !== Object.entries(validTokens).length)) {
-        await db
-          .collection(getUsersCollectionName())
-          .updateOne({ _id: userId }, { $set: { tokens: validTokens } }, { returnDocument: 'after' });
-      }
+    if (Object.entries(tokens).length !== Object.entries(validTokens).length) {
+      await db
+        .collection(getUsersCollectionName())
+        .updateOne({ _id: userId }, { $set: { tokens: validTokens } }, { returnDocument: 'after' });
     }
   } catch (e) {
     debug(e);

--- a/services/auth/lib/tokens.js
+++ b/services/auth/lib/tokens.js
@@ -1,6 +1,7 @@
 const debug = require('debug')('campsi:auth:tokens');
+const { getUsersCollectionName } = require('./modules/collectionNames');
 
-async function deleteExpiredTokens(tokens, userId, db) {
+async function deleteExpiredTokens(tokens, userId, db, providersToRemove = []) {
   try {
     const validTokens = {};
     const expiredTokensLog = [];
@@ -12,7 +13,7 @@ async function deleteExpiredTokens(tokens, userId, db) {
     // iterate over users tokens
     if (Object.entries(tokens)) {
       for (const [key, token] of Object.entries(tokens)) {
-        if (token.expiration > new Date()) {
+        if (!providersToRemove.includes(token.grantedByProvider) || token.expiration > new Date()) {
           validTokens[`${key}`] = token;
         } else {
           expiredTokensLog.push({
@@ -25,7 +26,7 @@ async function deleteExpiredTokens(tokens, userId, db) {
 
       if (expiredTokensLog.length) {
         try {
-          await db.collection('__users__.tokens_log').insertMany(expiredTokensLog);
+          await db.collection(`${getUsersCollectionName()}.tokens_log`).insertMany(expiredTokensLog);
         } catch (ex) {
           debug(ex);
         }

--- a/services/auth/lib/tokens.js
+++ b/services/auth/lib/tokens.js
@@ -13,7 +13,7 @@ async function deleteExpiredTokens(tokens, userId, db, providersToRemove = []) {
     // iterate over users tokens
     if (Object.entries(tokens)) {
       for (const [key, token] of Object.entries(tokens)) {
-        if (!providersToRemove.includes(token.grantedByProvider) || token.expiration > new Date()) {
+        if (token.expiration > new Date() && !providersToRemove.includes(token.provider)) {
           validTokens[`${key}`] = token;
         } else {
           expiredTokensLog.push({

--- a/services/auth/lib/tokens.js
+++ b/services/auth/lib/tokens.js
@@ -29,9 +29,6 @@ async function deleteExpiredTokens(tokens, userId, db, providersToRemove = []) {
       } catch (ex) {
         debug(ex);
       }
-    }
-
-    if (Object.entries(tokens).length !== Object.entries(validTokens).length) {
       await db
         .collection(getUsersCollectionName())
         .updateOne({ _id: userId }, { $set: { tokens: validTokens } }, { returnDocument: 'after' });


### PR DESCRIPTION
title self-explanatory
in passport proxy callback middleware:
- user doesn't exists: we create it
- user exists, has one identity, but not the one we are trying to login with: we return an error with the provider the provider the user should login with
- user exists and has multiple identities: we update it by removing the other ones, to keep only the one the user is trying to login with. we also remove related tokens
- user exists, but has no identities (for instance: invitation): we update it
- user exists, has only one identity: the one we are trying to login with: we update it too



Also: `deleteExpiredTokens` refactored/cleaned up