### PR TITLE
Dev 3511 improvement/add disposable email domains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "connect-mongodb-session": "^3.1.1",
         "cors": "^2.8.5",
         "crypto-js": "^3.1.9-1",
+        "disposable-email-domains": "^1.0.62",
         "edit-url": "^1.0.1",
         "eslint-config-axeptio": "^1.0.0",
         "eslint-plugin-n": "^15.2.0",
@@ -3199,6 +3200,11 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/disposable-email-domains": {
+      "version": "1.0.62",
+      "resolved": "https://registry.npmjs.org/disposable-email-domains/-/disposable-email-domains-1.0.62.tgz",
+      "integrity": "sha512-LBQvhRw7mznQTPoyZbsmYeNOZt1pN5aCsx4BAU/3siVFuiM9f2oyKzUaB8v1jbxFjE3aYqYiMo63kAL4pHgfWQ=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -10077,6 +10083,7 @@
         "crypto-js": "^3.1.9-1",
         "debug": "^3.2.6",
         "depcheck": "^1.2.0",
+        "disposable-email-domains": "^1.0.62",
         "edit-url": "^1.0.1",
         "eslint": "^8.13.0",
         "eslint-config-axeptio": "^1.0.0",
@@ -12662,6 +12669,11 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
           "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
           "dev": true
+        },
+        "disposable-email-domains": {
+          "version": "1.0.62",
+          "resolved": "https://registry.npmjs.org/disposable-email-domains/-/disposable-email-domains-1.0.62.tgz",
+          "integrity": "sha512-LBQvhRw7mznQTPoyZbsmYeNOZt1pN5aCsx4BAU/3siVFuiM9f2oyKzUaB8v1jbxFjE3aYqYiMo63kAL4pHgfWQ=="
         },
         "doctrine": {
           "version": "3.0.0",
@@ -16774,6 +16786,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
+    },
+    "disposable-email-domains": {
+      "version": "1.0.62",
+      "resolved": "https://registry.npmjs.org/disposable-email-domains/-/disposable-email-domains-1.0.62.tgz",
+      "integrity": "sha512-LBQvhRw7mznQTPoyZbsmYeNOZt1pN5aCsx4BAU/3siVFuiM9f2oyKzUaB8v1jbxFjE3aYqYiMo63kAL4pHgfWQ=="
     },
     "doctrine": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "connect-mongodb-session": "^3.1.1",
     "cors": "^2.8.5",
     "crypto-js": "^3.1.9-1",
+    "disposable-email-domains": "^1.0.62",
     "edit-url": "^1.0.1",
     "eslint-config-axeptio": "^1.0.0",
     "eslint-plugin-n": "^15.2.0",

--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -9,6 +9,7 @@ const { ObjectId } = require('mongodb');
 const { deleteExpiredTokens } = require('./tokens');
 const { getUsersCollectionName } = require('./modules/collectionNames');
 const createObjectId = require('../../../lib/modules/createObjectId');
+const disposableDomains = require('disposable-email-domains');
 
 async function tokenMaintenance(req, res) {
   if (!req?.user?.isAdmin) {
@@ -540,8 +541,14 @@ async function softDelete(req, res) {
   }
 }
 
+function checkDisposableEmail(email) {
+  const domain = email.split('@')[1];
+  return disposableDomains.includes(domain);
+}
+
 module.exports = {
   initAuth,
+  checkDisposableEmail,
   redirectWithError,
   callback,
   getProviders,

--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -541,6 +541,13 @@ async function softDelete(req, res) {
   }
 }
 
+/**
+ * The function checks if an email address belongs to a disposable email domain.
+ * @param email - The email parameter is a string representing an email address.
+ * @returns a boolean value indicating whether the domain of the given email is included in the `disposableDomains` array. If the
+ * domain is included, the function will return `true`, indicating that the email is a disposable email. If the domain is not
+ * included, the function will return `false`, indicating that the email is not a disposable email.
+ */
 function checkDisposableEmail(email) {
   const domain = email.split('@')[1];
   return disposableDomains.includes(domain);


### PR DESCRIPTION
DEV-3511

In this PR, we add a new exportable function.
The function checks if an email address belongs to a disposable email domain.

In another issue, we will integrate this function in the auth service.

Tested locally