### PR TITLE
fix: add a common regex for mail verification and add a todo

### DIFF
--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -550,7 +550,10 @@ async function softDelete(req, res) {
  */
 function checkDisposableEmail(email) {
   const domain = email.split('@')[1];
-  return disposableDomains.includes(domain);
+  return (
+    !/^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,3})$/i.test(email) ||
+    disposableDomains.includes(domain)
+  );
 }
 
 module.exports = {

--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -542,15 +542,15 @@ async function softDelete(req, res) {
 }
 
 /**
- * The function checks if an email address belongs to a disposable email domain.
- * @param email - The email parameter is a string representing an email address.
- * @returns a boolean value indicating whether the domain of the given email is included in the `disposableDomains` array. If the
- * domain is included, the function will return `true`, indicating that the email is a disposable email. If the domain is not
- * included, the function will return `false`, indicating that the email is not a disposable email.
+ * The function checks if an email is valid and not from a disposable domain.
+ * @param email - The email parameter is a string representing an email address that needs to be validated.
+ * @returns The function `isEmailValid` returns a boolean value indicating whether the input email
+ * is valid or not. It checks if the email matches the regular expression for a valid email format
+ * and if the domain is not included in the `disposableDomains` array.
  */
-function checkDisposableEmail(email) {
+function isEmailValid(email) {
   const domain = email.split('@')[1];
-  return (
+  return !(
     !/^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i.test(email) ||
     disposableDomains.includes(domain)
   );
@@ -558,7 +558,7 @@ function checkDisposableEmail(email) {
 
 module.exports = {
   initAuth,
-  checkDisposableEmail,
+  isEmailValid,
   redirectWithError,
   callback,
   getProviders,

--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -551,7 +551,7 @@ async function softDelete(req, res) {
 function checkDisposableEmail(email) {
   const domain = email.split('@')[1];
   return (
-    !/^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,3})$/i.test(email) ||
+    !/^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i.test(email) ||
     disposableDomains.includes(domain)
   );
 }

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -4,6 +4,7 @@ const helpers = require('../../../lib/modules/responseHelpers');
 const state = require('./state');
 const bcrypt = require('bcryptjs');
 const { getUsersCollectionName } = require('./modules/collectionNames');
+const { checkDisposableEmail } = require('./handlers');
 const debug = require('debug')('campsi:auth:local');
 
 function getMissingParameters(payload, parameters) {
@@ -168,7 +169,7 @@ module.exports.signup = function (req, res) {
   };
 
   if (req.body.email) {
-    if (!/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(req.body.email)) {
+    if (checkDisposableEmail(req.body.email)) {
       return helpers.error(res, new Error('Invalid email'));
     }
   }

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -4,7 +4,7 @@ const helpers = require('../../../lib/modules/responseHelpers');
 const state = require('./state');
 const bcrypt = require('bcryptjs');
 const { getUsersCollectionName } = require('./modules/collectionNames');
-const { checkDisposableEmail } = require('./handlers');
+const { isEmailValid } = require('./handlers');
 const debug = require('debug')('campsi:auth:local');
 
 function getMissingParameters(payload, parameters) {
@@ -169,7 +169,7 @@ module.exports.signup = function (req, res) {
   };
 
   if (req.body.email) {
-    if (checkDisposableEmail(req.body.email)) {
+    if (!isEmailValid(req.body.email)) {
       return helpers.error(res, new Error('Invalid email'));
     }
   }

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -382,6 +382,7 @@ module.exports = class StripeBillingService extends CampsiService {
     return creditNotes;
   };
 
+  // TODO: change by checkDisposableEmail function
   checkEmailValidity (email) {
     const regex = new RegExp(
       /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -2,6 +2,7 @@
 const CampsiService = require('../../../lib/service');
 const helpers = require('../../../lib/modules/responseHelpers');
 const crypto = require('crypto');
+const { checkDisposableEmail } = require("../../auth/lib/handlers");
 
 const subscriptionExpand = ['latest_invoice', 'latest_invoice.payment_intent', 'pending_setup_intent'];
 const customerExpand = ['tax_ids'];
@@ -382,12 +383,8 @@ module.exports = class StripeBillingService extends CampsiService {
     return creditNotes;
   };
 
-  // TODO: change by checkDisposableEmail function
   checkEmailValidity (email) {
-    const regex = new RegExp(
-      /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i
-    );
-    if (!regex.test(email)) {
+    if (checkDisposableEmail(email)) {
       throw new Error('Invalid Email');
     }
   };

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -2,7 +2,7 @@
 const CampsiService = require('../../../lib/service');
 const helpers = require('../../../lib/modules/responseHelpers');
 const crypto = require('crypto');
-const { checkDisposableEmail } = require("../../auth/lib/handlers");
+const { isEmailValid } = require("../../auth/lib/handlers");
 
 const subscriptionExpand = ['latest_invoice', 'latest_invoice.payment_intent', 'pending_setup_intent'];
 const customerExpand = ['tax_ids'];
@@ -384,7 +384,7 @@ module.exports = class StripeBillingService extends CampsiService {
   };
 
   checkEmailValidity (email) {
-    if (checkDisposableEmail(email)) {
+    if (!isEmailValid(email)) {
       throw new Error('Invalid Email');
     }
   };


### PR DESCRIPTION
In this PR, we just centralize the regex present in campsi-mono in an exportable function  