### PR TITLE
feat: add/validate invitation on existing user (DEV-3664)

### DIFF
--- a/services/auth/lib/passportMiddleware.js
+++ b/services/auth/lib/passportMiddleware.js
@@ -62,7 +62,13 @@ module.exports = function passportMiddleware(req) {
       } else if (existingProvidersIdentities.length > 1) {
         // user exists and has multiple identities: we update it by removing the other ones, to keep only the one the user is trying to login with
         delete update.$set[`identities.${provider.name}`];
-        update.$set.identities = { [provider.name]: profile.identity };
+        const udpatedIdentities = { [provider.name]: profile.identity };
+        Object.entries(existingUser.identities).forEach(([key, value]) => {
+          if (!existingProvidersIdentities.includes(key)) {
+            udpatedIdentities[key] = value;
+          }
+        });
+        update.$set.identities = udpatedIdentities;
         providersToRemove = existingProvidersIdentities.filter(providerName => providerName !== provider.name);
       }
       /*


### PR DESCRIPTION
title self-explanatory

For now, invitation token is not stored in db when an invitation is sent to an already existing user
Thus, this invitation can't be accepted.
This PR fixes this.