### PR TITLE
fix: user local signup with existing invitations (DEV-3677)

### DIFF
--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -144,6 +144,7 @@ module.exports.signup = function (req, res) {
         $set: {
           'identities.local': user.identities.local,
           email: user.email,
+          displayName: user.displayName,
           data: user.data,
           updatedAt: new Date()
         }

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -158,20 +158,6 @@ module.exports.signup = function (req, res) {
     }
   };
 
-  const acceptInvitation = async function (user, invitationToken, req) {
-    const invitation = doc.identities[`invitation-${req.params.invitationToken}`];
-    const payload = {
-      userId: req.user._id,
-      invitedUserId: doc._id,
-      invitedBy: invitation.invitedBy,
-      data: invitation.data,
-      requestBody: req.body,
-      requestHeaders: req.headers
-    };
-    res.json(payload);
-    req.service.emit('invitation/accepted', payload);
-  };
-
   const doesUserExist = async function (user) {
     try {
       return await users.findOne({ email: user.email });


### PR DESCRIPTION
title self-explanatory

Til now, an existing user without any providers (=> created through invitation), could not signup without using the invitation signup form.
This PR fixes that. (Tested)