### PR TITLE
chore: remove token singular references (DEV-3525)

### DIFF
--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -180,7 +180,6 @@ function createAnonymousUser(req, res) {
       }
     },
     email: token.value,
-    token: token.value,
     createdAt: new Date()
   };
   req.db

--- a/services/auth/lib/modules/queryBuilder.js
+++ b/services/auth/lib/modules/queryBuilder.js
@@ -25,7 +25,6 @@ function genBearerToken(expiration) {
 function genUpdate(provider, profile) {
   const update = { $set: {} };
   const token = genBearerToken(provider.expiration);
-  update.$set.token = token.value;
   update.$set[`tokens.${token.value}`] = {
     expiration: token.expiration,
     grantedByProvider: provider.name
@@ -58,7 +57,6 @@ function genInsert(provider, profile) {
   };
   insert.invitedBy = profile.identity.invitedBy;
   insert.identities[provider.name] = profile.identity;
-  insert.token = token.value;
   insert.tokens = {
     [token.value]: {
       expiration: token.expiration,

--- a/test/auth/auth-local-password-reset.js
+++ b/test/auth/auth-local-password-reset.js
@@ -31,26 +31,17 @@ const services = {
 };
 
 const signin = (chai, campsi, username, password) =>
-  chai
-    .request(campsi.app)
-    .post('/auth/local/signin')
-    .send({ username, password });
+  chai.request(campsi.app).post('/auth/local/signin').send({ username, password });
 
 const createResetPasswordToken = (chai, campsi, email) =>
-  chai
-    .request(campsi.app)
-    .post('/auth/local/reset-password-token')
-    .send({ email });
+  chai.request(campsi.app).post('/auth/local/reset-password-token').send({ email });
 
 const resetUserPassword = (chai, campsi, username, passwordResetToken, newPassword) =>
-  chai
-    .request(campsi.app)
-    .post('/auth/local/reset-password')
-    .send({
-      username,
-      token: passwordResetToken,
-      password: newPassword
-    });
+  chai.request(campsi.app).post('/auth/local/reset-password').send({
+    username,
+    token: passwordResetToken,
+    password: newPassword
+  });
 
 describe('Auth Local Password Reset', () => {
   const context = {};
@@ -71,7 +62,7 @@ describe('Auth Local Password Reset', () => {
 
           signin(chai, campsi, glenda.username, firstPassword).end((err, res) => {
             if (err) debug(`received an error from chai: ${err.message}`);
-            res.should.have.status(400);
+            res.should.have.status(401);
             res.should.be.json;
             res.body.should.not.have.property('token');
 

--- a/test/auth/auth-local-passwordRegex.js
+++ b/test/auth/auth-local-passwordRegex.js
@@ -73,7 +73,7 @@ describe('Auth Local Password Regex', () => {
 
           signin(chai, campsi, glenda.username, firstPassword).end((err, res) => {
             if (err) debug(`received an error from chai: ${err.message}`);
-            res.should.have.status(400);
+            res.should.have.status(401);
             res.should.be.json;
             res.body.should.not.have.property('token');
 

--- a/test/auth/auth-local.js
+++ b/test/auth/auth-local.js
@@ -175,7 +175,7 @@ describe('Auth Local API', () => {
           chai
             .request(campsi.app)
             .post('/auth/local/signup')
-            .set('Authorization', 'Bearer ' + res.body.token)
+            .set('Authorization', 'Bearer ' + Object.keys(res.body.tokens)?.[0])
             .send(glenda)
             .end((err, res) => {
               if (err) debug(`received an error from chai: ${err.message}`);
@@ -284,10 +284,7 @@ describe('Auth Local API', () => {
           cb => {
             chai
               .request(campsi.app)
-              .get(
-                '/auth/local/validate?token=differentFromValidationToken&redirectURI=' +
-                  encodeURIComponent('/trace/local-signup-validate-redirect')
-              )
+              .get('/auth/local/validate?token=differentFromValidationToken')
               .end((err, res) => {
                 if (err) debug(`received an error from chai: ${err.message}`);
                 res.should.have.status(404);
@@ -397,7 +394,7 @@ describe('Auth Local API', () => {
           })
           .end((err, res) => {
             if (err) debug(`received an error from chai: ${err.message}`);
-            res.should.have.status(400);
+            res.should.have.status(401);
             res.should.be.json;
             res.body.should.be.a('object');
             res.body.should.have.property('message');

--- a/test/auth/auth.js
+++ b/test/auth/auth.js
@@ -206,7 +206,7 @@ describe('Auth API', () => {
             res.body.should.have.property('displayName');
             res.body.should.have.property('email');
             res.body.should.have.property('identities');
-            res.body.should.have.property('token');
+            res.body.should.have.property('tokens');
             done();
           });
       });
@@ -224,7 +224,7 @@ describe('Auth API', () => {
           res.should.have.status(200);
           res.should.be.json;
           res.body.should.be.a('object');
-          res.body.should.have.property('token');
+          res.body.should.have.property('tokens');
           done();
         });
     });
@@ -415,7 +415,7 @@ describe('Auth API', () => {
             res.body.should.have.property('displayName');
             res.body.should.have.property('email');
             res.body.should.have.property('identities');
-            res.body.should.have.property('token');
+            res.body.should.have.property('tokens');
             done();
           });
       });
@@ -646,17 +646,16 @@ describe('Auth API', () => {
             payload.should.have.property('invitedUserId');
             payload.should.have.property('data');
             payload.data.projectId.should.eq('testProjectId');
-
-            chai
-              .request(campsi.app)
-              .post(`/auth/invitations/${invitationToken.value}`)
-              .set('Authorization', 'Bearer ' + glendaToken)
-              .end((err, res) => {
-                if (err) reject(debug(`received an error from chai: ${err.message}`));
-                res.should.have.status(404);
-                resolve();
-              });
           });
+          chai
+            .request(campsi.app)
+            .post(`/auth/invitations/${invitationToken.value}`)
+            .set('Authorization', 'Bearer ' + glendaToken)
+            .end((err, res) => {
+              if (err) reject(debug(`received an error from chai: ${err.message}`));
+              res.should.have.status(404);
+              resolve();
+            });
         });
 
         const inviteAcceptRes = await chai

--- a/test/auth/delete.js
+++ b/test/auth/delete.js
@@ -9,7 +9,7 @@ const format = require('string-format');
 const config = require('config');
 const createUser = require('../helpers/createUser');
 const setupBeforeEach = require('../helpers/setupBeforeEach');
-const { ObjectId, ObjectID } = require('mongodb');
+const { ObjectId } = require('mongodb');
 const expect = chai.expect;
 format.extend(String.prototype);
 chai.use(chaiHttp);
@@ -17,7 +17,7 @@ chai.should();
 
 const createProject = function (id) {
   return {
-    _id: new ObjectID(),
+    _id: new ObjectId(),
     users: {
       [id]: {
         roles: ['owner'],
@@ -33,7 +33,7 @@ const createProject = function (id) {
         createdBy: new ObjectId(),
         data: {},
         modifiedAt: new Date(),
-        modifiedBy: new ObjectID()
+        modifiedBy: new ObjectId()
       }
     }
   };

--- a/test/docs/events.js
+++ b/test/docs/events.js
@@ -94,44 +94,47 @@ describe('Events', () => {
       );
 
       let documentId;
-      async.series([
-        cb => {
-          // POST
-          chai
-            .request(campsi.app)
-            .post('/docs/simple/state-public')
-            .set('content-type', 'application/json')
-            .send({ name: 'test' })
-            .end((err, res) => {
-              if (err) debug(`received an error from chai: ${err.message}`);
-              documentId = res.body.id;
-              cb();
-            });
-        },
-        cb => {
-          // PUT
-          chai
-            .request(campsi.app)
-            .put(`/docs/simple/${documentId}`)
-            .set('content-type', 'application/json')
-            .send({ name: 'test modified' })
-            .end(cb);
-        },
-        cb => {
-          // CHANGE STATE
-          chai
-            .request(campsi.app)
-            .put(`/docs/simple/${documentId}/state`)
-            .set('content-type', 'application/json')
-            .send({ from: 'state-public', to: 'state-basic' })
-            .end(cb);
-        },
-        cb => {
-          // DELETE
-          chai.request(campsi.app).delete(`/docs/simple/${documentId}`).set('content-type', 'application/json').end(cb);
-        }
-      ]);
-    });
+      async.series(
+        [
+          cb => {
+            // POST
+            chai
+              .request(campsi.app)
+              .post('/docs/simple/state-public')
+              .set('content-type', 'application/json')
+              .send({ name: 'test' })
+              .end((err, res) => {
+                if (err) debug(`received an error from chai: ${err.message}`);
+                documentId = res.body.id;
+                cb();
+              });
+          },
+          cb => {
+            // PUT
+            chai
+              .request(campsi.app)
+              .put(`/docs/simple/${documentId}`)
+              .set('content-type', 'application/json')
+              .send({ name: 'test modified' })
+              .end(cb);
+          },
+          cb => {
+            // CHANGE STATE
+            chai
+              .request(campsi.app)
+              .put(`/docs/simple/${documentId}/state`)
+              .set('content-type', 'application/json')
+              .send({ from: 'state-public', to: 'state-basic' })
+              .end(cb);
+          },
+          cb => {
+            // DELETE
+            chai.request(campsi.app).delete(`/docs/simple/${documentId}`).set('content-type', 'application/json').end(cb);
+          }
+        ],
+        done
+      );
+    }).timeout(5000);
     it('should dispatch events for document users POST / PUT / DELETE', done => {
       // event listeners
       async.parallel(

--- a/test/docs/soft-delete.js
+++ b/test/docs/soft-delete.js
@@ -7,7 +7,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const format = require('string-format');
 const config = require('config');
-const { ObjectId, ObjectID } = require('mongodb');
+const { ObjectId } = require('mongodb');
 const setupBeforeEach = require('../helpers/setupBeforeEach');
 const createUser = require('../helpers/createUser');
 
@@ -23,7 +23,7 @@ const services = {
 
 const createProject = function (id) {
   return {
-    _id: new ObjectID(),
+    _id: new ObjectId(),
     users: {
       [id]: {
         roles: ['owner'],
@@ -39,7 +39,7 @@ const createProject = function (id) {
         createdBy: new ObjectId(),
         data: {},
         modifiedAt: new Date(),
-        modifiedBy: new ObjectID()
+        modifiedBy: new ObjectId()
       }
     }
   };


### PR DESCRIPTION
title self-explanatory (we don't use `user.token` anymore)
all auth unit tests are green and have been fixed

Note: I've fixed auth unit tests, and some tests of docs service, but some more are broken.
Since they're unrelated to this issue, I've created [another issue](https://linear.app/axeptio/issue/DEV-3979/fix-campsi-broken-unit-tests), for later