### PR TITLE
fix: patch requests only validate the payload (DEV-4094)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20625,7 +20625,7 @@
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "ajv": "^8.11.0",
-        "ajv-errors": "*",
+        "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
         "async": "^2.6.3",
         "bcryptjs": "^2.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@passport-next/passport-http-bearer": "^1.2.0",
         "@passport-next/passport-local": "^1.2.0",
         "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
         "bcryptjs": "^2.4.3",
         "busboy-body-parser": "^0.3.2",
@@ -4284,6 +4285,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
       }
     },
     "node_modules/ajv-formats": {
@@ -20105,6 +20114,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "requires": {}
+    },
     "ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -20610,6 +20625,7 @@
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "ajv": "^8.11.0",
+        "ajv-errors": "*",
         "ajv-formats": "^2.1.1",
         "async": "^2.6.3",
         "bcryptjs": "^2.4.3",
@@ -24049,6 +24065,12 @@
             "require-from-string": "^2.0.2",
             "uri-js": "^4.2.2"
           }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
         },
         "ajv-formats": {
           "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@passport-next/passport-http-bearer": "^1.2.0",
     "@passport-next/passport-local": "^1.2.0",
     "ajv": "^8.11.0",
+    "ajv-errors": "^3.0.0",
     "ajv-formats": "^2.1.1",
     "bcryptjs": "^2.4.3",
     "busboy-body-parser": "^0.3.2",

--- a/services/audit/index.js
+++ b/services/audit/index.js
@@ -6,6 +6,7 @@ const utils = require('./utils.js');
 const JournalService = require('./services/journal');
 const Ajv = require('ajv');
 const addFormats = require('ajv-formats');
+const ajvErrors = require('ajv-errors');
 
 module.exports = class AuditService extends CampsiService {
   initialize() {
@@ -29,7 +30,8 @@ module.exports = class AuditService extends CampsiService {
   }
 
   setupSchemaValidation(resource, schema) {
-    const ajvReader = new Ajv({ useAssign: true, strictTuples: false, strict: false });
+    const ajvReader = new Ajv({ allErrors: true, useAssign: true, strictTuples: false, strict: false });
+    ajvErrors(ajvReader);
     addFormats(ajvReader, ['date-time']);
 
     try {

--- a/services/docs/lib/handlers.js
+++ b/services/docs/lib/handlers.js
@@ -25,7 +25,7 @@ function dispatchError(res, error) {
   switch (true) {
     case error instanceof ValidationError:
       return helpers.validationError(res, error);
-    case error.message === 'Not Found':
+    case error.message.includes('Not Found'):
       return helpers.notFound(res, error);
     case error.message === 'Unauthorized':
       return helpers.unauthorized(res, error);
@@ -155,6 +155,7 @@ module.exports.patchDoc = async (req, res) => {
       req.state,
       req.options.resources
     );
+
     const result = await documentService.patchDocument(req.resource, req.filter, req.body, req.state, req.user);
     helpers.json(res, result);
     req.service.emit(

--- a/services/docs/lib/index.js
+++ b/services/docs/lib/index.js
@@ -4,6 +4,7 @@ const param = require('./param');
 const handlers = require('./handlers');
 const async = require('async');
 const Ajv = require('ajv');
+const ajvErrors = require('ajv-errors');
 const addFormats = require('ajv-formats');
 const $RefParser = require('json-schema-ref-parser');
 const debug = require('debug')('campsi:docs');
@@ -218,10 +219,12 @@ module.exports = class DocsService extends CampsiService {
     );
 
     return new Promise(resolve => {
-      const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: false });
+      const ajvWriter = new Ajv({ allErrors: true, useAssign: true, strictTuples: false, strict: false });
+      ajvErrors(ajvWriter);
       addFormats(ajvWriter);
       csdAssign(ajvWriter);
-      const ajvReader = new Ajv({ useVisibility: true, strictTuples: false, strict: false });
+      const ajvReader = new Ajv({ allErrors: true, useVisibility: true, strictTuples: false, strict: false });
+      ajvErrors(ajvReader);
       addFormats(ajvReader);
       csdVisibility(ajvReader);
       async.eachOf(

--- a/services/docs/lib/modules/queryBuilder.js
+++ b/services/docs/lib/modules/queryBuilder.js
@@ -307,6 +307,18 @@ module.exports.patch = async options => {
   return ops;
 };
 
+/**
+ * @param {Object}  options
+ * @param {Resource} options.resource
+ * @param {Object} options.data
+ * @param {String} [options.state]
+ * @returns {Promise<void>}
+ */
+module.exports.validatePatchedDocument = async options => {
+  const state = getStateFromOptions(options);
+  await validate(options.resource, sanitizeHTMLFromXSS(options.data), state.validate);
+};
+
 module.exports.deleteFilter = function deleteDoc(options) {
   const filter = {};
   filter._id = options.id;

--- a/services/docs/lib/modules/queryBuilder.js
+++ b/services/docs/lib/modules/queryBuilder.js
@@ -311,7 +311,7 @@ module.exports.patch = async options => {
  * @param {Object}  options
  * @param {Resource} options.resource
  * @param {Object} options.data
- * @param {String} [options.state]
+ * @param {String} options.state
  * @returns {Promise<void>}
  */
 module.exports.validatePatchedDocument = async options => {

--- a/services/docs/lib/services/document.js
+++ b/services/docs/lib/services/document.js
@@ -364,8 +364,7 @@ module.exports.patchDocument = async (resource, filter, data, state, user) => {
     await builder.validatePatchedDocument({
       resource,
       data: updateDoc.value.states[state].data,
-      state,
-      user
+      state
     });
   } catch (e) {
     const { _id, ...replacement } = originalRawDocument;

--- a/services/notifications/index.js
+++ b/services/notifications/index.js
@@ -3,6 +3,7 @@ const CampsiService = require('../../lib/service');
 const debug = require('debug')('campsi:notifications');
 const handlers = require('./handlers');
 const Ajv = require('ajv');
+const ajvErrors = require('ajv-errors');
 const addFormats = require('ajv-formats');
 const csdAssign = require('../../lib/keywords/csdAssign');
 const csdVisibility = require('../../lib/keywords/csdVisibility');
@@ -33,10 +34,12 @@ module.exports = class NotificationsService extends CampsiService {
     this.router.deleteAsync('/:resource/:id', handlers.deleteNotification);
 
     return new Promise(resolve => {
-      const ajvWriter = new Ajv({ useAssign: true, strictTuples: false, strict: false });
+      const ajvWriter = new Ajv({ allErrors: true, useAssign: true, strictTuples: false, strict: false });
+      ajvErrors(ajvWriter);
       csdAssign(ajvWriter);
       addFormats(ajvWriter);
-      const ajvReader = new Ajv({ useVisibility: true, strictTuples: false, strict: false });
+      const ajvReader = new Ajv({ allErrors: true, useVisibility: true, strictTuples: false, strict: false });
+      ajvErrors(ajvReader);
       csdVisibility(ajvReader);
       addFormats(ajvReader);
 

--- a/services/versioned-docs/lib/index.js
+++ b/services/versioned-docs/lib/index.js
@@ -3,6 +3,7 @@ const CampsiService = require('../../../lib/service');
 const param = require('./param');
 const handlers = require('./handlers');
 const Ajv = require('ajv');
+const ajvErrors = require('ajv-errors');
 const $RefParser = require('json-schema-ref-parser');
 const debug = require('debug')('campsi:versioned-docs');
 const csdAssign = require('../../../lib/keywords/csdAssign');
@@ -34,9 +35,11 @@ module.exports = class VersionedDocsService extends CampsiService {
     this.router.patchAsync('/:resource/:id', handlers.updateDoc);
     this.router.deleteAsync('/:resource/:id', handlers.delDoc);
 
-    const ajvWriter = new Ajv({ useAssign: true, strict: false });
+    const ajvWriter = new Ajv({ allErrors: true, useAssign: true, strict: false });
+    ajvErrors(ajvWriter);
     csdAssign(ajvWriter);
-    const ajvReader = new Ajv({ useVisibility: true, strict: false });
+    const ajvReader = new Ajv({ allErrors: true, useVisibility: true, strict: false });
+    ajvErrors(ajvReader);
     csdVisibility(ajvReader);
     try {
       return Promise.all(


### PR DESCRIPTION
patch requests only validate the payload, not the whole document data. But some validations may depend on other props, for instance this in JSON schema spec won't work if only one of these 2 props is passed:
```JSON
"allOf": [
    {
      "not": {
        "required": ["marketplace", "organizationId"]
      }
    }
  ]
```

Note: added `ajv-errors` package to allow custom error messages in JSON schema specs