### PR TITLE
fix: trying to redefine non-empty obj

### DIFF
--- a/services/docs/lib/modules/queryBuilder.js
+++ b/services/docs/lib/modules/queryBuilder.js
@@ -324,7 +324,11 @@ const patchAJsonDoc = (originalJson, patchData) => {
     if (patchData[key] === null) {
       dot.delete(key, originalJson);
     } else {
-      dot.str(key, patchData[key], originalJson);
+      if (Array.isArray(patchData[key])) {
+        dot.set(key, patchData[key], originalJson);
+      } else {
+        dot.str(key, patchData[key], originalJson);
+      }
     }
   });
 


### PR DESCRIPTION
This bug can occur when the value to patch is an array