### PR TITLE
feat: improve payment_method usage

### DIFF
--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -329,9 +329,10 @@ module.exports = class StripeBillingService extends CampsiService {
     this.router.post('/setup_intents', async (req, res) => {
       const params = {
         confirm: true,
-        payment_method: req.body.payment_method,
         customer: req.body.customer,
+        payment_method: req.body.payment_method,
         payment_method_types: ['card', 'sepa_debit'],
+        payment_method_options: req.body.payment_method_options,
         metadata: req.body.metadata
       };
       const idempotencyKey = this.createIdempotencyKey(params, 'setupIntents.create');

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -177,7 +177,8 @@ module.exports = class StripeBillingService extends CampsiService {
         promotion_code: req.body.promotion_code,
         expand: buildExpandFromBody(req.body, subscriptionExpand),
         default_tax_rates: req.body.default_tax_rates,
-        default_source: req.body.default_source
+        default_source: req.body.default_source,
+        default_payment_method: req.body.default_payment_method
       };
       if (req.body.currency) {
         params.currency = req.body.currency;
@@ -222,7 +223,8 @@ module.exports = class StripeBillingService extends CampsiService {
         promotion_code: req.body.promotion_code,
         expand: buildExpandFromBody(req.body, subscriptionExpand),
         default_tax_rates: req.body.default_tax_rates,
-        default_source: req.body.default_source
+        default_source: req.body.default_source,
+        default_payment_method: req.body.default_payment_method
       });
       res.json(subscription);
     });
@@ -335,6 +337,17 @@ module.exports = class StripeBillingService extends CampsiService {
         payment_method_options: req.body.payment_method_options,
         metadata: req.body.metadata
       };
+      if (req.body.payment_method_options?.sepa_debit || req.body.payment_method_type === 'sepa_debit') {
+        params.mandate_data = {
+          customer_acceptance: {
+            type: 'online',
+            online: {
+              ip_address: req.headers['x-forwarded-for'] || req.ip,
+              user_agent: req.headers['user-agent']
+            }
+          }
+        };
+      }
       const idempotencyKey = this.createIdempotencyKey(params, 'setupIntents.create');
       const setupIntent = await stripe.setupIntents.create(params, { idempotencyKey });
       res.json(setupIntent);

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -245,6 +245,17 @@ module.exports = class StripeBillingService extends CampsiService {
       res.json(paymentMethod);
     });
 
+    this.router.patch('/payment_methods/:id', async (req, res) => {
+      const params = {};
+      ['billing_details', 'metadata', 'allow_redisplay'].forEach(param => {
+        if (req.body.hasOwnProperty(param)) {
+          params[param] = req.body[param];
+        }
+      });
+      const paymentMethod = await stripe.paymentMethods.update(req.params.id, params);
+      res.json(paymentMethod);
+    });
+
     this.router.get('/invoices/:id', async (req, res) => {
       const invoice = await stripe.invoices.retrieve(req.params.id, optionsFromQuery(req.query));
       res.json(invoice);
@@ -347,6 +358,9 @@ module.exports = class StripeBillingService extends CampsiService {
             }
           }
         };
+      }
+      if (req.body.expand) {
+        params.expand = buildExpandFromBody(req.body);
       }
       const idempotencyKey = this.createIdempotencyKey(params, 'setupIntents.create');
       const setupIntent = await stripe.setupIntents.create(params, { idempotencyKey });

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -137,6 +137,16 @@ module.exports = class StripeBillingService extends CampsiService {
       res.json(deletion);
     });
 
+    this.router.post('/customers/:customer/payment_methods', async (req, res) => {
+      const paymentMethod = await stripe.paymentMethods.attach(req.body.payment_method, { customer: req.params.customer });
+      res.json(paymentMethod);
+    });
+
+    this.router.delete('/customers/:customer/payment_methods/:id', async (req, res) => {
+      const deletion = await stripe.paymentMethods.detach(req.params.id);
+      res.json(deletion);
+    });
+
     this.router.delete('/customers/:customer/tax_ids/:id', async (req, res) => {
       const deletion = await stripe.customers.deleteTaxId(req.params.customer, req.params.id);
       res.json(deletion);
@@ -211,6 +221,11 @@ module.exports = class StripeBillingService extends CampsiService {
     this.router.get('/sources/:id', async (req, res) => {
       const source = await stripe.sources.retrieve(req.params.id, optionsFromQuery(req.query));
       res.json(source);
+    });
+
+    this.router.get('/payment_methods/:id', async (req, res) => {
+      const paymentMethod = await stripe.paymentMethods.retrieve(req.params.id, optionsFromQuery(req.query));
+      res.json(paymentMethod);
     });
 
     this.router.get('/invoices/:id', async (req, res) => {

--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -142,6 +142,21 @@ module.exports = class StripeBillingService extends CampsiService {
       res.json(paymentMethod);
     });
 
+    this.router.get('/customers/:customer/payment_methods', async (req, res) => {
+      const paymentMethods = [];
+      const params = {
+        customer: req.params.customer,
+        limit: 100
+      };
+      if (req.query.type) {
+        params.type = req.query.type;
+      }
+      for await (const paymentMethod of stripe.paymentMethods.list(params)) {
+        paymentMethods.push(paymentMethod);
+      }
+      res.json(paymentMethods);
+    });
+
     this.router.delete('/customers/:customer/payment_methods/:id', async (req, res) => {
       const deletion = await stripe.paymentMethods.detach(req.params.id);
       res.json(deletion);


### PR DESCRIPTION
Lots of stuff due to the deprecation of SEPA Debit Sources in favor of SEPA Debit Payment Method
- list all customer's payment methods
- attach a payment method to a customer
- patch a payment_method
- setup_intent creation improved
- payment_intent related routes updated