### PR TITLE
fix: patching whole object

### DIFF
--- a/services/docs/lib/modules/queryBuilder.js
+++ b/services/docs/lib/modules/queryBuilder.js
@@ -324,10 +324,10 @@ const patchAJsonDoc = (originalJson, patchData) => {
     if (patchData[key] === null) {
       dot.delete(key, originalJson);
     } else {
-      if (Array.isArray(patchData[key])) {
-        dot.set(key, patchData[key], originalJson);
-      } else {
+      if (typeof patchData[key] === 'string') {
         dot.str(key, patchData[key], originalJson);
+      } else {
+        dot.set(key, patchData[key], originalJson);
       }
     }
   });

--- a/test/docs/validation.js
+++ b/test/docs/validation.js
@@ -153,6 +153,29 @@ describe('Validation', () => {
       expect(result.details.description).to.equal('Old Description'); // Ensure other fields remain unchanged
     });
 
+    it('should update a field with an object', function () {
+      const originalJson = {
+        name: 'Sample Name',
+        details: {
+          description: 'Old Description',
+          info: {
+            year: 2020,
+            author: 'John Doe'
+          }
+        }
+      };
+
+      const patchData = {
+        'details.info': { year: 2025 }
+      };
+
+      const result = patchAJsonDoc(originalJson, patchData);
+
+      expect(result.details.info.year).to.equal(2025);
+      expect(result.details.info.author).to.equal(undefined);
+      expect(result.details.description).to.equal('Old Description'); // Ensure other fields remain unchanged
+    });
+
     it('should handle an empty patch data object', function () {
       const originalJson = {
         name: 'Sample Name',


### PR DESCRIPTION
to avoid this kind of error:
```json
{
"message":"Trying to redefine non-empty obj['default_payment_method']",
"stack":["Error: Trying to redefine non-empty obj['default_payment_method']","    at DotObject._fill (C:\\Users\\roro\\Documents\\Agilitation\\DevProjects\\caas-api\\node_modules\\dot-object\\index.js:118:15)","    at DotObject._fill (C:\\Users\\roro\\Documents\\Agilitation\\DevProjects\\caas-api\\node_modules\\dot-object\\index.js:114:10)","    at DotObject._fill (C:\\Users\\roro\\Documents\\Agilitation\\DevProjects\\caas-api\\node_modules\\dot-object\\index.js:114:10)","    at DotObject.str (C:\\Users\\roro\\Documents\\Agilitation\\DevProjects\\caas-api\\node_modules\\dot-object\\index.js:179:10)","    at Function.str (C:\\Users\\roro\\Documents\\Agilitation\\DevProjects\\caas-api\\node_modules\\dot-object\\index.js:90:31)","    at C:\\Users\\roro\\Documents\\Agilitation\\DevProjects\\caas-api\\node_modules\\campsi\\services\\docs\\lib\\modules\\queryBuilder.js:330:13","    at Array.forEach (<anonymous>)","    at patchAJsonDoc (C:\\Users\\roro\\Documents\\Agilitation\\DevProjects\\caas-api\\node_modules\\campsi\\services\\docs\\lib\\modules\\queryBuilder.js:323:26)","    at validatePatchedDocument (C:\\Users\\roro\\Documents\\Agilitation\\DevProjects\\caas-api\\node_modules\\campsi\\services\\docs\\lib\\modules\\queryBuilder.js:351:11)","    at module.exports.patch (C:\\Users\\roro\\Documents\\Agilitation\\DevProjects\\caas-api\\node_modules\\campsi\\services\\docs\\lib\\modules\\queryBuilder.js:305:9)"]
}
```

`dot.str` is for strings


unit tests added (note: some tests are failing, but unrelated to this PR, they also fail on master and will have to be fixed in another branch)