### PR TITLE
fix: (not for production) add a delete endpoint for deleting the current user.

### DIFF
--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -188,6 +188,22 @@ async function patchMe(req, res) {
   }
 }
 
+async function deleteMe(req, res) {
+  if (!req.user) {
+    return helpers.unauthorized(res);
+  }
+
+  try {
+    const usersCollection = await getUsersCollection(req.campsi, req.service.path);
+    const result = await usersCollection.deleteOne({ _id: req.user._id });
+    res.json(result);
+
+    req.service.emit('user/deleted', { userId: req.user._id });
+  } catch (e) {
+    helpers.error(res, e);
+  }
+}
+
 async function createAnonymousUser(req, res) {
   const token = builder.genBearerToken(100);
   const insert = {
@@ -691,6 +707,7 @@ module.exports = {
   me,
   updateMe,
   patchMe,
+  deleteMe,
   createAnonymousUser,
   logout,
   inviteUser,

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -76,6 +76,10 @@ module.exports = class AuthService extends CampsiService {
     router.get('/me', validateRedirectURI, handlers.me);
     router.put('/me', handlers.updateMe);
     router.patch('/me', handlers.patchMe);
+    if (process.env.NODE_ENV !== 'production') {
+      // used by end-to-end tests
+      router.delete('/me', handlers.deleteMe);
+    }
     router.get('/anonymous', handlers.createAnonymousUser);
     router.get('/logout', handlers.logout);
     router.post('/invitations', handlers.inviteUser);


### PR DESCRIPTION
Used by end-to-end tests.