### PR TITLE
feat: rate limit local auth endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Manage and expose **document-oriented** content through a configurable RESTful *
 - [x] Role-Based Access-Control
 - [x] Generate invitation tokens by role
 - [x] PassportJS integration
-- [x] Custom authentification providers
+- [x] Custom authentication providers
     - [x] [Local Database](lib/modules/auth/auth-local.js)
     - [x] [Facebook](lib/modules/auth/facebook.js)
     - [x] [Github](lib/modules/auth/github.js)
     - [x] [Google](lib/modules/auth/google.js)
-- [ ] Rate limiter
+- [x] Rate limiter
 
 #### Other
 - [ ] Swagger / API doc generation

--- a/lib/middlewares/rateLimit.js
+++ b/lib/middlewares/rateLimit.js
@@ -5,21 +5,15 @@ const rateLimitMiddleware = function (rateLimits) {
     const rateLimiterKey = rateLimits.key + ':' + ipaddress;
     const redis = req.campsi.redis;
     const rPerWindow = rateLimits.requests ?? 5;
-    redis.setnx(rateLimiterKey, rPerWindow + 1).then(newKey => {
-      const decr = () => {
-        redis.decr(rateLimiterKey).then(n => {
-          if (!n || n <= 0) {
-            serviceNotAvailableRetryAfterSeconds(res, 1, rateLimits.message, rateLimits.key);
-          } else {
-            next();
-          }
-        });
-      };
-      if (newKey) {
-        redis.expire(rateLimiterKey, rateLimits.window /* for testing: * 60 */).then(decr);
-      } else {
-        decr();
-      }
+    const ttl = rateLimits.window; // for testing: * 60
+    redis.set(rateLimiterKey, rPerWindow + 1, 'NX', 'EX', ttl).then(newKey => {
+      redis.decr(rateLimiterKey).then(n => {
+        if (!n || n <= 0) {
+          serviceNotAvailableRetryAfterSeconds(res, 1, rateLimits.message, rateLimits.key);
+        } else {
+          next();
+        }
+      });
     });
   };
 };

--- a/lib/middlewares/rateLimit.js
+++ b/lib/middlewares/rateLimit.js
@@ -1,12 +1,21 @@
 const { serviceNotAvailableRetryAfterSeconds } = require('../modules/responseHelpers');
 
 /**
- * Apply defaults to rate limits data:
- *  key: 'auth-local',
- *  requests: 5,
- *  window: 1
+ * @typedef {Object} RateLimits
+ * @property {string} key - key prefix for redis, like limit's name
+ * @property {string} requests - number of requests to allow in a time window
+ * @property {string} window - number of seconds to apply the rate limit for
  */
-const rateLimitDefaults = (rateLimits) => {
+
+/**
+ * Apply defaults to rate limits incoming data.
+ * Ensures key, requests and window are set.
+ * @param {RateLimits?} [rateLimits]
+ * @param {string} [rateLimits.key = 'auth-local'] redis key prefix
+ * @param {number} [rateLimits.requests = 5] number of requests in a window
+ * @param {number} [rateLimits.window = 1] number of seconds in a window
+ */
+const rateLimitDefaults = rateLimits => {
   const settings = rateLimits ? { ...rateLimits } : {};
   if (!settings.key) {
     settings.key = 'auth-local';

--- a/lib/middlewares/rateLimit.js
+++ b/lib/middlewares/rateLimit.js
@@ -4,13 +4,13 @@ const rateLimitMiddleware = function (rateLimits) {
     const ipaddress = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
     const rateLimiterKey = rateLimits.key + ':' + ipaddress;
     const redis = req.campsi.redis;
-    const rps = rateLimits.requestsPerSecond ?? 5;
-    redis.setnx(rateLimiterKey, rps + 1).then(newKey => {
+    const rPerWindow = rateLimits.requests ?? 5;
+    redis.setnx(rateLimiterKey, rPerWindow + 1).then(newKey => {
       const getAndDecr = ignore2 => {
         redis.get(rateLimiterKey).then(ignore3 => {
           redis.decr(rateLimiterKey).then(n => {
             if (n <= 0) {
-              serviceNotAvailableRetryAfterSeconds(res, 1);
+              serviceNotAvailableRetryAfterSeconds(res, 1, rateLimits.message, rateLimits.key);
             } else {
               next();
             }
@@ -18,7 +18,7 @@ const rateLimitMiddleware = function (rateLimits) {
         });
       };
       if (newKey) {
-        redis.expire(rateLimiterKey, 1 /* for testing: * 60 */).then(getAndDecr);
+        redis.expire(rateLimiterKey, rateLimits.window /* for testing: * 60 */).then(getAndDecr);
       } else {
         getAndDecr();
       }
@@ -28,4 +28,4 @@ const rateLimitMiddleware = function (rateLimits) {
 
 module.exports = {
   rateLimitMiddleware
-}
+};

--- a/lib/middlewares/rateLimit.js
+++ b/lib/middlewares/rateLimit.js
@@ -1,0 +1,31 @@
+const { serviceNotAvailableRetryAfterSeconds } = require('../modules/responseHelpers');
+const rateLimitMiddleware = function (rateLimits) {
+  return (req, res, next) => {
+    const ipaddress = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+    const rateLimiterKey = rateLimits.key + ':' + ipaddress;
+    const redis = req.campsi.redis;
+    const rps = rateLimits.requestsPerSecond ?? 5;
+    redis.setnx(rateLimiterKey, rps + 1).then(newKey => {
+      const getAndDecr = ignore2 => {
+        redis.get(rateLimiterKey).then(ignore3 => {
+          redis.decr(rateLimiterKey).then(n => {
+            if (n <= 0) {
+              serviceNotAvailableRetryAfterSeconds(res, 1);
+            } else {
+              next();
+            }
+          });
+        });
+      };
+      if (newKey) {
+        redis.expire(rateLimiterKey, 1 /* for testing: * 60 */).then(getAndDecr);
+      } else {
+        getAndDecr();
+      }
+    });
+  };
+};
+
+module.exports = {
+  rateLimitMiddleware
+}

--- a/lib/middlewares/rateLimit.js
+++ b/lib/middlewares/rateLimit.js
@@ -6,21 +6,19 @@ const rateLimitMiddleware = function (rateLimits) {
     const redis = req.campsi.redis;
     const rPerWindow = rateLimits.requests ?? 5;
     redis.setnx(rateLimiterKey, rPerWindow + 1).then(newKey => {
-      const getAndDecr = ignore2 => {
-        redis.get(rateLimiterKey).then(ignore3 => {
-          redis.decr(rateLimiterKey).then(n => {
-            if (n <= 0) {
-              serviceNotAvailableRetryAfterSeconds(res, 1, rateLimits.message, rateLimits.key);
-            } else {
-              next();
-            }
-          });
+      const decr = () => {
+        redis.decr(rateLimiterKey).then(n => {
+          if (!n || n <= 0) {
+            serviceNotAvailableRetryAfterSeconds(res, 1, rateLimits.message, rateLimits.key);
+          } else {
+            next();
+          }
         });
       };
       if (newKey) {
-        redis.expire(rateLimiterKey, rateLimits.window /* for testing: * 60 */).then(getAndDecr);
+        redis.expire(rateLimiterKey, rateLimits.window /* for testing: * 60 */).then(decr);
       } else {
-        getAndDecr();
+        decr();
       }
     });
   };

--- a/lib/middlewares/rateLimit.js
+++ b/lib/middlewares/rateLimit.js
@@ -1,5 +1,27 @@
 const { serviceNotAvailableRetryAfterSeconds } = require('../modules/responseHelpers');
-const rateLimitMiddleware = function (rateLimits) {
+
+/**
+ * Apply defaults to rate limits data:
+ *  key: 'auth-local',
+ *  requests: 5,
+ *  window: 1
+ */
+const rateLimitDefaults = (rateLimits) => {
+  const settings = rateLimits ? { ...rateLimits } : {};
+  if (!settings.key) {
+    settings.key = 'auth-local';
+  }
+  if (!settings.requests) {
+    settings.requests = 5;
+  }
+  if (!settings.window) {
+    settings.window = 1;
+  }
+  return settings;
+};
+
+const rateLimitMiddleware = function (_rateLimits) {
+  const rateLimits = rateLimitDefaults(_rateLimits);
   return (req, res, next) => {
     const ipaddress = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
     const rateLimiterKey = rateLimits.key + ':' + ipaddress;

--- a/lib/modules/responseHelpers.js
+++ b/lib/modules/responseHelpers.js
@@ -82,6 +82,12 @@ module.exports.serviceNotAvailable = (res, err) => {
   send(res, 503, body);
 };
 
+module.exports.serviceNotAvailableRetryAfterSeconds = (res, seconds) => {
+  const body = { message: 'service unavailable' };
+  res.header('Retry-After', seconds);
+  send(res, 503, body);
+};
+
 // Advanced Error handlers
 module.exports.error = function(res, err) {
   let result = false;

--- a/lib/modules/responseHelpers.js
+++ b/lib/modules/responseHelpers.js
@@ -82,9 +82,12 @@ module.exports.serviceNotAvailable = (res, err) => {
   send(res, 503, body);
 };
 
-module.exports.serviceNotAvailableRetryAfterSeconds = (res, seconds) => {
-  const body = { message: 'service unavailable' };
+module.exports.serviceNotAvailableRetryAfterSeconds = (res, seconds, message, key) => {
+  const body = { message: message ?? 'service unavailable' };
   res.header('Retry-After', seconds);
+  if (key) {
+    res.header('X-Rate-Limiter', key);
+  }
   send(res, 503, body);
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,7 @@ const express = require('express');
 require('async');
 require('express-async-errors');
 const { MongoClient } = require('mongodb');
+const Redis = require('ioredis');
 const { URL } = require('url');
 const { ValidationError } = require('express-json-validator-middleware');
 const pinoHttp = require('pino-http');
@@ -68,6 +69,7 @@ class CampsiServer extends MQTTEmitter {
 
   async start() {
     await this.dbConnect();
+    await this.redisConnect();
     this.setupApp();
     await this.loadServices();
     this.describe();
@@ -79,6 +81,21 @@ class CampsiServer extends MQTTEmitter {
     const client = await MongoClient.connect(campsiServer.config.mongo.uri);
     campsiServer.dbClient = client;
     campsiServer.db = client.db(campsiServer.config.mongo.database);
+  }
+
+  async redisConnect() {
+    const campsiServer = this;
+    campsiServer.redis = new Redis(campsiServer.config.redis);
+    await new Promise((resolve, reject) => {
+      campsiServer.redis.ping((err, res) => {
+        if (err || !res) {
+          reject(err);
+        } else {
+          debug('Redis connected.');
+          resolve();
+        }
+      });
+    });
   }
 
   setupApp() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "express-json-validator-middleware": "^2.2.1",
         "express-session": "^1.16.1",
         "http-errors": "^2.0.0",
+        "ioredis": "^4.28.0",
         "jsdom": "^22.1.0",
         "json-schema-ref-parser": "^5.0.3",
         "just-diff": "^5.0.1",
@@ -5003,6 +5004,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/coffee-script": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
@@ -5529,6 +5539,15 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depcheck": {
@@ -8008,6 +8027,64 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/ioredis": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+      "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/ioredis/node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
@@ -8737,17 +8814,35 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true
     },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -13481,6 +13576,33 @@
         "esprima": "~4.0.0"
       }
     },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+      "license": "MIT"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -14515,6 +14637,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -19336,6 +19464,7 @@
         "find-process": "^1.4.7",
         "http-errors": "^2.0.0",
         "husky": "^8.0.1",
+        "ioredis": "^4.28.0",
         "jsdom": "^22.1.0",
         "json-schema-ref-parser": "^5.0.3",
         "just-diff": "^5.0.1",
@@ -23283,6 +23412,11 @@
           "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "dev": true
         },
+        "cluster-key-slot": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+          "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+        },
         "coffee-script": {
           "version": "1.12.7",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
@@ -23675,6 +23809,11 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "denque": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+          "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
         },
         "depcheck": {
           "version": "1.4.2",
@@ -25500,6 +25639,44 @@
             "loose-envify": "^1.0.0"
           }
         },
+        "ioredis": {
+          "version": "4.28.5",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+          "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+          "requires": {
+            "cluster-key-slot": "^1.1.0",
+            "debug": "^4.3.1",
+            "denque": "^1.1.0",
+            "lodash.defaults": "^4.2.0",
+            "lodash.flatten": "^4.4.0",
+            "lodash.isarguments": "^3.1.0",
+            "p-map": "^2.1.0",
+            "redis-commands": "1.7.0",
+            "redis-errors": "^1.2.0",
+            "redis-parser": "^3.0.0",
+            "standard-as-callback": "^2.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.4.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+              "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+              "requires": {
+                "ms": "^2.1.3"
+              }
+            },
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            },
+            "p-map": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+              "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+            }
+          }
+        },
         "ip": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
@@ -26050,17 +26227,32 @@
           "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
           "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
         },
+        "lodash.defaults": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+          "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+        },
         "lodash.escaperegexp": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
           "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
           "dev": true
         },
+        "lodash.flatten": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+          "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+        },
         "lodash.get": {
           "version": "4.4.2",
           "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
           "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
           "dev": true
+        },
+        "lodash.isarguments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+          "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
         },
         "lodash.isplainobject": {
           "version": "4.0.6",
@@ -29333,6 +29525,24 @@
             "esprima": "~4.0.0"
           }
         },
+        "redis-commands": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+          "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+        },
+        "redis-errors": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+          "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+        },
+        "redis-parser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+          "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+          "requires": {
+            "redis-errors": "^1.0.0"
+          }
+        },
         "regexpp": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -30074,6 +30284,11 @@
             "safer-buffer": "^2.0.2",
             "tweetnacl": "~0.14.0"
           }
+        },
+        "standard-as-callback": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+          "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
         },
         "statuses": {
           "version": "1.5.0",
@@ -30986,6 +31201,11 @@
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+    },
     "coffee-script": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
@@ -31378,6 +31598,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depcheck": {
       "version": "1.4.2",
@@ -33203,6 +33428,44 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "ioredis": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+      "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+      "requires": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+        }
+      }
+    },
     "ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
@@ -33753,17 +34016,32 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true
     },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -37036,6 +37314,24 @@
         "esprima": "~4.0.0"
       }
     },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -37777,6 +38073,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "statuses": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "express-json-validator-middleware": "^2.2.1",
     "express-session": "^1.16.1",
     "http-errors": "^2.0.0",
+    "ioredis": "^4.28.0",
     "jsdom": "^22.1.0",
     "json-schema-ref-parser": "^5.0.3",
     "just-diff": "^5.0.1",

--- a/services/auth/lib/defaults.js
+++ b/services/auth/lib/defaults.js
@@ -1,0 +1,27 @@
+/**
+ * Apply defaults consistently to passwordRateLimits incoming
+ * data.
+ *
+ * ensures key, wrongPassword, wrongPasswordBlockForSeconds are set.
+ * defaults:
+ *  key: 'password-local'
+ *  wrongPassword: 5
+ *  wrongPasswordBlockForSeconds: 30
+ */
+const passwordRateLimitDefaults = (passwordRateLimits) => {
+  const settings = passwordRateLimits ? { ...passwordRateLimits } : {};
+  if (!settings.key) {
+    settings.key = 'password-local';
+  }
+  if (!settings.wrongPassword) {
+    settings.wrongPassword = 5;
+  }
+  if (!settings.wrongPasswordBlockForSeconds) {
+    settings.wrongPasswordBlockForSeconds = 30;
+  }
+  return settings;
+};
+
+module.exports = {
+  passwordRateLimitDefaults
+};

--- a/services/auth/lib/defaults.js
+++ b/services/auth/lib/defaults.js
@@ -1,14 +1,21 @@
 /**
+ * @typedef {Object} PasswordRateLimits
+ * @property {string} key - key prefix for redis, like limit's name
+ * @property {number} wrongPassword - number of password failures to allow
+ * @property {number} wrongPasswordBlockForSeconds - initial number of seconds to block, doubles each subsequent failure
+ */
+
+/**
  * Apply defaults consistently to passwordRateLimits incoming
  * data.
- *
  * ensures key, wrongPassword, wrongPasswordBlockForSeconds are set.
- * defaults:
- *  key: 'password-local'
- *  wrongPassword: 5
- *  wrongPasswordBlockForSeconds: 30
+ *  @param {PasswordRateLimits?} [passwordRateLimits]
+ *  @param {string} [passwordRateLimits.key = 'password-local'] redis key prefix
+ *  @param {number} [passwordRateLimits.wrongPassword = 5] number or allowed failures
+ *  @param {number} [passwordRateLimits.wrongPasswordBlockForSeconds = 30] initial block time
+ *  @return {PasswordRateLimits}
  */
-const passwordRateLimitDefaults = (passwordRateLimits) => {
+const passwordRateLimitDefaults = passwordRateLimits => {
   const settings = passwordRateLimits ? { ...passwordRateLimits } : {};
   if (!settings.key) {
     settings.key = 'password-local';

--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -10,6 +10,7 @@ const { deleteExpiredTokens } = require('./tokens');
 const { getUsersCollection } = require('./modules/authCollections');
 const createObjectId = require('../../../lib/modules/createObjectId');
 const disposableDomains = require('disposable-email-domains');
+const { serviceNotAvailableRetryAfterSeconds } = require('../../../lib/modules/responseHelpers');
 
 async function tokenMaintenance(req, res) {
   if (!req?.user?.isAdmin) {
@@ -243,6 +244,60 @@ function getProviders(req, res) {
   res.json(ret);
 }
 
+const passwordRateLimitImplementation = (passwordRateLimits, req, res, err, next) => {
+  // check rate limit on failed passwords.
+  //
+  // note: this works with passwordRateLimitMiddleware to stop passwords before
+  // they get to the endpoint for verification.
+  //
+  const e = err ?? (!req?.user ? createError(401, 'unable to authentify user') : null);
+  if (e !== null && passwordRateLimits !== undefined) {
+    // apply password error rate limits
+    const { key, wrongPassword, wrongPasswordBlockForSeconds } = passwordRateLimits;
+    const ipaddress = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+    const rateLimiterKey = key + ':' + ipaddress;
+    const redis = req.campsi.redis;
+    const ifNotExists = {
+      failures: 0,
+      remaining: wrongPassword + 1,
+      nextWait: wrongPasswordBlockForSeconds / 2,
+      blockUntil: null
+    };
+    redis.setnx(rateLimiterKey, JSON.stringify(ifNotExists)).then(() => {
+      redis.get(rateLimiterKey).then(value => {
+        const settings = JSON.parse(value);
+        let block = false;
+        let newExpire = settings.failures === 0 ? settings.nextWait * 2 : null;
+        settings.remaining--;
+        settings.failures++;
+        if (settings.remaining <= 0) {
+          settings.remaining = wrongPassword;
+          settings.nextWait *= 2;
+          newExpire = settings.nextWait;
+          block = true;
+          // eslint-disable-next-line prettier/prettier
+          settings.blockUntil = new Date().getTime() + (newExpire * 1000); // milliseconds
+        }
+        redis.set(rateLimiterKey, JSON.stringify(settings)).then(() => {
+          redis.expire(rateLimiterKey, 24 * 3600).then(() => {
+            if (block) {
+              if (newExpire) {
+                serviceNotAvailableRetryAfterSeconds(res, newExpire);
+              } else {
+                serviceNotAvailableRetryAfterSeconds(res, settings.nextWait / 2);
+              }
+            } else {
+              next();
+            }
+          });
+        });
+      });
+    });
+  } else {
+    next();
+  }
+};
+
 async function callback(req, res, next) {
   let { redirectURI } = state.get(req);
   const redirectUriFromState = !!redirectURI;
@@ -254,38 +309,51 @@ async function callback(req, res, next) {
     session: false,
     failWithError: true
   })(req, res, err => {
-    if (err) {
-      return redirectWithError(req, res, err, next);
-    }
-    if (!req.user) {
-      return redirectWithError(req, res, createError(401, 'unable to authentify user'), next);
-    }
-    if (!redirectURI) {
-      try {
-        res.json({ token: req.authBearerToken });
-      } catch (err) {
-        debug('Catching headers', err);
+    const loginFlow = (req, res, err) => {
+      if (err) {
+        return redirectWithError(req, res, err, next);
       }
-    } else {
-      if (req.authProvider.options?.validateRedirectURI && !req.authProvider.options.validateRedirectURI(redirectURI)) {
-        delete req.query.redirectURI;
-        return redirectWithError(req, res, createError(400, 'invalid redirectURI'), next);
+      if (!req?.user) {
+        return redirectWithError(req, res, createError(401, 'unable to authentify user'), next);
       }
-      if (req.method === 'GET' || redirectUriFromState) {
-        res.redirect(
-          editURL(redirectURI, obj => {
-            obj.query.access_token = req.authBearerToken;
-          })
-        );
+      if (!redirectURI) {
+        try {
+          res.json({ token: req.authBearerToken });
+        } catch (err) {
+          debug('Catching headers', err);
+        }
       } else {
-        res.json({ token: req.authBearerToken, redirectURI });
+        if (req.authProvider.options?.validateRedirectURI && !req.authProvider.options.validateRedirectURI(redirectURI)) {
+          delete req.query.redirectURI;
+          return redirectWithError(req, res, createError(400, 'invalid redirectURI'), next);
+        }
+        if (req.method === 'GET' || redirectUriFromState) {
+          res.redirect(
+            editURL(redirectURI, obj => {
+              obj.query.access_token = req.authBearerToken;
+            })
+          );
+        } else {
+          res.json({ token: req.authBearerToken, redirectURI });
+        }
       }
-    }
-    if (req.session) {
-      req.session.destroy(() => {
-        debug('session destroyed');
-      });
-    }
+      if (req.session) {
+        req.session.destroy(() => {
+          debug('session destroyed');
+        });
+      }
+    };
+    passwordRateLimitImplementation(
+      req.authProvider.options?.passwordRateLimits ?? {
+        key: 'password-local',
+        wrongPassword: 5,
+        wrongPasswordBlockForSeconds: 30
+      },
+      req,
+      res,
+      err,
+      () => loginFlow(req, res, err)
+    );
   });
 }
 

--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -282,9 +282,9 @@ const passwordRateLimitImplementation = (passwordRateLimits, req, res, err, next
           redis.expire(rateLimiterKey, 24 * 3600).then(() => {
             if (block) {
               if (newExpire) {
-                serviceNotAvailableRetryAfterSeconds(res, newExpire);
+                serviceNotAvailableRetryAfterSeconds(res, newExpire, null, key);
               } else {
-                serviceNotAvailableRetryAfterSeconds(res, settings.nextWait / 2);
+                serviceNotAvailableRetryAfterSeconds(res, settings.nextWait / 2, null, key);
               }
             } else {
               next();

--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -259,7 +259,7 @@ const passwordRateLimitImplementation = (passwordRateLimits, req, res, err, next
     const redis = req.campsi.redis;
     const ifNotExists = {
       failures: 0,
-      remaining: wrongPassword + 1,
+      remaining: wrongPassword,
       nextWait: wrongPasswordBlockForSeconds / 2,
       blockUntil: null
     };
@@ -271,7 +271,7 @@ const passwordRateLimitImplementation = (passwordRateLimits, req, res, err, next
         settings.remaining--;
         settings.failures++;
         if (settings.remaining <= 0) {
-          settings.remaining = wrongPassword;
+          settings.remaining = 1; // one more login attempt before a new ban
           settings.nextWait *= 2;
           newExpire = settings.nextWait;
           block = true;

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -93,7 +93,7 @@ module.exports = class AuthService extends CampsiService {
       router.use(
         '/local',
         local.localAuthMiddleware(providers.local),
-        libRateLimit.rateLimitMiddleware(providers.local.options?.rateLimits ?? { key: 'auth-local', requestsPerSecond: 5 })
+        libRateLimit.rateLimitMiddleware(providers.local.options?.rateLimits ?? { key: 'auth-local', requests: 5, window: 1 })
       );
       router.post('/local/signup', localSignupMiddleware, local.signup);
       router.post(

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -91,7 +91,7 @@ module.exports = class AuthService extends CampsiService {
     if (providers.local) {
       router.use('/local',
         local.localAuthMiddleware(providers.local),
-        local.rateLimitMiddleware(providers.local?.rateLimits ?? { key: 'auth-local', requestsPerMinute: 5 })
+        local.rateLimitMiddleware(providers.local?.rateLimits ?? { key: 'auth-local', requestsPerSecond: 5 })
       );
       router.post('/local/signup', localSignupMiddleware, local.signup);
       router.post('/local/signin', local.signin);

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -89,7 +89,10 @@ module.exports = class AuthService extends CampsiService {
     router.put('/tokens', handlers.tokenMaintenance);
 
     if (providers.local) {
-      router.use('/local', local.middleware(providers.local));
+      router.use('/local',
+        local.localAuthMiddleware(providers.local),
+        local.rateLimitMiddleware(providers.local?.rateLimits ?? { key: 'auth-local', requestsPerMinute: 5 })
+      );
       router.post('/local/signup', localSignupMiddleware, local.signup);
       router.post('/local/signin', local.signin);
       router.post('/local/reset-password-token', validatePasswordResetUrl, local.createResetPasswordToken);

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -93,18 +93,12 @@ module.exports = class AuthService extends CampsiService {
       router.use(
         '/local',
         local.localAuthMiddleware(providers.local),
-        libRateLimit.rateLimitMiddleware(providers.local.options?.rateLimits ?? { key: 'auth-local', requests: 5, window: 1 })
+        libRateLimit.rateLimitMiddleware(providers.local.options?.rateLimits)
       );
       router.post('/local/signup', localSignupMiddleware, local.signup);
       router.post(
         '/local/signin',
-        local.passwordRateLimitMiddleware(
-          providers.local.options?.passwordRateLimits ?? {
-            key: 'password-local',
-            wrongPassword: 5,
-            wrongPasswordBlockForSeconds: 30
-          }
-        ),
+        local.passwordRateLimitMiddleware(providers.local.options?.passwordRateLimits),
         local.signin
       );
       router.post('/local/reset-password-token', validatePasswordResetUrl, local.createResetPasswordToken);

--- a/services/auth/lib/index.js
+++ b/services/auth/lib/index.js
@@ -1,5 +1,6 @@
 const CampsiService = require('../../../lib/service');
 const local = require('./local');
+const libRateLimit = require('../../../lib/middlewares/rateLimit');
 const passportMiddleware = require('./passportMiddleware');
 const passport = require('@passport-next/passport');
 const helpers = require('../../../lib/modules/responseHelpers');
@@ -92,7 +93,7 @@ module.exports = class AuthService extends CampsiService {
       router.use(
         '/local',
         local.localAuthMiddleware(providers.local),
-        local.rateLimitMiddleware(providers.local.options?.rateLimits ?? { key: 'auth-local', requestsPerSecond: 5 })
+        libRateLimit.rateLimitMiddleware(providers.local.options?.rateLimits ?? { key: 'auth-local', requestsPerSecond: 5 })
       );
       router.post('/local/signup', localSignupMiddleware, local.signup);
       router.post(

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -7,6 +7,7 @@ const { getUsersCollection } = require('./modules/authCollections');
 const { isEmailValid } = require('./handlers');
 const editURL = require('edit-url');
 const { serviceNotAvailableRetryAfterSeconds } = require('../../../lib/modules/responseHelpers');
+const { passwordRateLimitDefaults } = require('./defaults');
 const debug = require('debug')('campsi:auth:local');
 
 function getMissingParameters(payload, parameters) {
@@ -41,7 +42,8 @@ const localAuthMiddleware = function (localProvider) {
  * note: this works with passwordRateLimitImplementation to provide a rate
  * limit on password *FAILURES*.
  */
-const passwordRateLimitMiddleware = function (passwordRateLimits) {
+const passwordRateLimitMiddleware = function (_passwordRateLimits) {
+  const passwordRateLimits = passwordRateLimitDefaults(_passwordRateLimits);
   return (req, res, next) => {
     const ipaddress = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
     const rateLimiterKey = passwordRateLimits.key + ':' + ipaddress;

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -37,9 +37,10 @@ const localAuthMiddleware = function (localProvider) {
   };
 };
 
-// note: this works with passwordRateLimitImplementation to provide a rate
-// limit on password *FAILURES*.
-//
+/**
+ * note: this works with passwordRateLimitImplementation to provide a rate
+ * limit on password *FAILURES*.
+ */
 const passwordRateLimitMiddleware = function (passwordRateLimits) {
   return (req, res, next) => {
     const ipaddress = req.headers['x-forwarded-for'] || req.socket.remoteAddress;

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -42,13 +42,13 @@ const rateLimitMiddleware = function (rateLimits) {
     const ipaddress = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
     const rateLimiterKey = rateLimits.key + ':' + ipaddress;
     const redis = req.campsi.redis;
-    const rpm = rateLimits.requestsPerMinute ?? 5;
+    const rpm = rateLimits.requestsPerSecond ?? 5;
     redis.setnx(rateLimiterKey, rpm + 1).then(ignore1 => {
-      redis.expire(rateLimiterKey, 60).then(ignore2 => {
+      redis.expire(rateLimiterKey, 1).then(ignore2 => {
         redis.get(rateLimiterKey).then(ignore3 => {
           redis.decr(rateLimiterKey).then(n => {
             if (n <= 0) {
-              serviceNotAvailableRetryAfterSeconds(res, 60);
+              serviceNotAvailableRetryAfterSeconds(res, 1);
             } else {
               next();
             }

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -50,7 +50,7 @@ const passwordRateLimitMiddleware = function (passwordRateLimits) {
         const settings = JSON.parse(value);
         const now = new Date().getTime();
         if (settings.blockUntil && now < settings.blockUntil) {
-          serviceNotAvailableRetryAfterSeconds(res, Math.ceil((settings.blockUntil - now) / 1000));
+          serviceNotAvailableRetryAfterSeconds(res, Math.ceil((settings.blockUntil - now) / 1000), null, passwordRateLimits.key);
         } else {
           next();
         }

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -514,7 +514,7 @@ const updatePassword = async function (req, res) {
 
 module.exports = {
   localAuthMiddleware,
-  rateLimitMiddleware: rateLimitMiddleware,
+  rateLimitMiddleware,
   signin,
   callback,
   encryptPassword,

--- a/services/auth/lib/local.js
+++ b/services/auth/lib/local.js
@@ -64,6 +64,9 @@ const rateLimitMiddleware = function (rateLimits) {
   };
 };
 
+// note: this works with passwordRateLimitImplementation to provide a rate
+// limit on password *FAILURES*.
+//
 const passwordRateLimitMiddleware = function (passwordRateLimits) {
   return (req, res, next) => {
     const ipaddress = req.headers['x-forwarded-for'] || req.socket.remoteAddress;


### PR DESCRIPTION
Add two types of rate limit to the local auth endpoints - a general rate limit for all APIs and also a password failure rate limit on the signin endpoint

Rate limits are implemented via redis.