### PR TITLE
fix: wrongly formed expand in subscription cancellation

### DIFF
--- a/services/stripe-billing/lib/index.js
+++ b/services/stripe-billing/lib/index.js
@@ -212,6 +212,9 @@ module.exports = class StripeBillingService extends CampsiService {
           params[param] = req.body[param];
         }
       });
+      if (params.expand) {
+        params.expand = buildExpandFromBody(req.body, subscriptionExpand);
+      }
       const canceledSubscription = await stripe.subscriptions.del(req.params.id, params);
       res.json(canceledSubscription);
     });


### PR DESCRIPTION
self-explanatory