### PR TITLE
Fix: allow configuration to enable the rate limit logic to be skipped.

### DIFF
--- a/lib/middlewares/rateLimit.js
+++ b/lib/middlewares/rateLimit.js
@@ -33,6 +33,9 @@ const rateLimitDefaults = rateLimits => {
 const rateLimitMiddleware = function (_rateLimits) {
   const rateLimits = rateLimitDefaults(_rateLimits);
   return (req, res, next) => {
+    if (skipRateLimiter(rateLimits, req)) {
+      return next();
+    }
     const ipaddress = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
     const rateLimiterKey = rateLimits.key + ':' + ipaddress;
     const redis = req.campsi.redis;
@@ -50,6 +53,16 @@ const rateLimitMiddleware = function (_rateLimits) {
   };
 };
 
+const skipRateLimiter = function (rateLimits, req) {
+  if (rateLimits?.ignore && rateLimits.ignore?.header && rateLimits.ignore?.value) {
+    if (req.headers[rateLimits.ignore.header.toLowerCase()] === rateLimits.ignore.value) {
+      return true; // skip processing.
+    }
+  }
+  return false;
+};
+
 module.exports = {
-  rateLimitMiddleware
+  rateLimitMiddleware,
+  skipRateLimiter
 };

--- a/services/auth/lib/handlers.js
+++ b/services/auth/lib/handlers.js
@@ -12,6 +12,7 @@ const createObjectId = require('../../../lib/modules/createObjectId');
 const disposableDomains = require('disposable-email-domains');
 const { serviceNotAvailableRetryAfterSeconds } = require('../../../lib/modules/responseHelpers');
 const { passwordRateLimitDefaults } = require('./defaults');
+const { skipRateLimiter } = require('../../../lib/middlewares/rateLimit');
 
 async function tokenMaintenance(req, res) {
   if (!req?.user?.isAdmin) {
@@ -271,6 +272,9 @@ const passwordRateLimiter = async (_passwordRateLimits, req, res, err, next) => 
   const passwordRateLimits = passwordRateLimitDefaults(_passwordRateLimits);
   const e = err ?? (!req?.user ? createError(401, 'unable to authentify user') : null);
   if (e === null) {
+    return next();
+  }
+  if (skipRateLimiter(passwordRateLimits, req)) {
     return next();
   }
 


### PR DESCRIPTION
Fix: allow configuration to enable the rate limit logic to be skipped, e.g. from unit tests.  Configure an ignore header and value.